### PR TITLE
Feat: ForwardAuth user creation follows OIDC library attribution preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ services:
       - /your/local/path/to/booklore/data:/app/data
       - /your/local/path/to/booklore/books:/books
       - /your/local/path/to/booklore/bookdrop:/bookdrop # 👈 Bookdrop directory
-```      
-      
+```
+
 ## 🔑 OIDC/OAuth2 Authentication (Authentik, Pocket ID, etc.)
 
 
@@ -168,6 +168,13 @@ For detailed instructions on setting up OIDC authentication:
 
 - 📺 [YouTube video on configuring Authentik with BookLore](https://www.youtube.com/watch?v=r6Ufh9ldF9M)
 - 📘 [Step-by-step setup guide for Pocket ID](docs/OIDC-Setup-With-PocketID.md)
+
+## 🛡️ Forward Auth with Reverse Proxy
+
+BookLore also supports **Forward Auth** (also known as Remote Auth) for authentication through reverse proxies like **Traefik**, **Nginx**, or **Caddy**. Forward Auth works by having your reverse proxy handle authentication and pass user information via HTTP headers to BookLore. This can be set up with providers like **Authelia** and **Authentik**.
+
+For detailed setup instructions and configuration examples:
+- 📘 [Complete Forward Auth Setup Guide](docs/forward-auth-with-proxy.md)
 
 ## 🤝 Community & Support
 
@@ -199,4 +206,3 @@ Thanks to all the amazing people who contribute to Booklore.
 
 * [GNU GPL v3](http://www.gnu.org/licenses/gpl.html)
 * Copyright 2024-2025
-

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/user/UserProvisioningService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/user/UserProvisioningService.java
@@ -9,6 +9,7 @@ import com.adityachandel.booklore.model.entity.*;
 import com.adityachandel.booklore.model.enums.*;
 import com.adityachandel.booklore.repository.LibraryRepository;
 import com.adityachandel.booklore.repository.UserRepository;
+import com.adityachandel.booklore.service.appsettings.AppSettingService;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class UserProvisioningService {
     private final LibraryRepository libraryRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private final UserDefaultsService userDefaultsService;
+    private final AppSettingService appSettingService;
 
     public boolean isInitialUserAlreadyProvisioned() {
         return userRepository.count() > 0;
@@ -142,18 +144,36 @@ public class UserProvisioningService {
         user.setProvisioningMethod(ProvisioningMethod.REMOTE);
         user.setPasswordHash("RemoteUser_" + RandomStringUtils.secure().nextAlphanumeric(32));
 
+        OidcAutoProvisionDetails oidcAutoProvisionDetails = appSettingService.getAppSettings().getOidcAutoProvisionDetails();
+        
         UserPermissionsEntity permissions = new UserPermissionsEntity();
         permissions.setUser(user);
-        permissions.setPermissionUpload(true);
-        permissions.setPermissionDownload(true);
-        permissions.setPermissionEditMetadata(true);
-        permissions.setPermissionEmailBook(true);
-        permissions.setPermissionDeleteBook(true);
+        
+        if (oidcAutoProvisionDetails != null && oidcAutoProvisionDetails.getDefaultPermissions() != null) {
+            List<String> defaultPermissions = oidcAutoProvisionDetails.getDefaultPermissions();
+            permissions.setPermissionUpload(defaultPermissions.contains("permissionUpload"));
+            permissions.setPermissionDownload(defaultPermissions.contains("permissionDownload"));
+            permissions.setPermissionEditMetadata(defaultPermissions.contains("permissionEditMetadata"));
+            permissions.setPermissionManipulateLibrary(defaultPermissions.contains("permissionManipulateLibrary"));
+            permissions.setPermissionEmailBook(defaultPermissions.contains("permissionEmailBook"));
+            permissions.setPermissionDeleteBook(defaultPermissions.contains("permissionDeleteBooks"));
+        } else {
+            permissions.setPermissionUpload(true);
+            permissions.setPermissionDownload(true);
+            permissions.setPermissionEditMetadata(true);
+            permissions.setPermissionManipulateLibrary(false);
+            permissions.setPermissionEmailBook(true);
+            permissions.setPermissionDeleteBook(true);
+        }
+        
         permissions.setPermissionAdmin(isAdmin);
         user.setPermissions(permissions);
 
         if (isAdmin) {
             List<LibraryEntity> libraries = libraryRepository.findAll();
+            user.setLibraries(new ArrayList<>(libraries));
+        } else if (oidcAutoProvisionDetails != null && oidcAutoProvisionDetails.getDefaultLibraryIds() != null && !oidcAutoProvisionDetails.getDefaultLibraryIds().isEmpty()) {
+            List<LibraryEntity> libraries = libraryRepository.findAllById(oidcAutoProvisionDetails.getDefaultLibraryIds());
             user.setLibraries(new ArrayList<>(libraries));
         }
 

--- a/docs/forward-auth-with-proxy.md
+++ b/docs/forward-auth-with-proxy.md
@@ -1,0 +1,68 @@
+# Forward Auth with Reverse Proxy
+
+BookLore supports **Forward Auth**, allowing you to specify when a user is logged in using a reverse proxy and existing SSO provider.
+
+## ⚠️ Security
+
+** Important**: Enabling forward auth means BookLore will **fully trust headers sent by the reverse proxy**. Never expose BookLore directly to the internet when using forward auth - always route through your authenticated proxy, otherwise outsiders can attempt to impersonate any username they know about.
+
+## Configuration
+
+Provide BookLore with the following environment variables:
+
+```bash
+# Allows Forward Auth
+REMOTE_AUTH_ENABLED=true
+
+# Enable automatic user creation (recommended)
+REMOTE_AUTH_CREATE_NEW_USERS=true
+
+# Header names (your proxy will specify what header names to use)
+REMOTE_AUTH_HEADER_USER=Remote-User        # Username (required)
+REMOTE_AUTH_HEADER_NAME=Remote-Name        # Display name
+REMOTE_AUTH_HEADER_EMAIL=Remote-Email      # Email address
+REMOTE_AUTH_HEADER_GROUPS=Remote-Groups    # Groups/roles
+
+# Admin group name (optional)
+REMOTE_AUTH_ADMIN_GROUP=admin              # Specify this if you want a group to automatically get admin rights
+```
+
+### Docker Compose Example
+
+```yaml
+services:
+  booklore:
+    image: ghcr.io/adityachandelgit/booklore-app:latest
+    environment:
+      # Forward Auth Configuration
+      - REMOTE_AUTH_ENABLED=true
+      - REMOTE_AUTH_CREATE_NEW_USERS=true
+      - REMOTE_AUTH_HEADER_NAME=Remote-Name
+      - REMOTE_AUTH_HEADER_USER=Remote-User
+      - REMOTE_AUTH_HEADER_EMAIL=Remote-Email
+      - REMOTE_AUTH_HEADER_GROUPS=Remote-Groups
+      - REMOTE_AUTH_ADMIN_GROUP=admin
+    # ... rest of configuration ...
+```
+
+## Setting Up Defaults Permissions
+
+1. **Access Admin Settings**: Log in to Booklore as an admin user
+2. **Navigate to Authentication Settings**: Go to Settings → Authentication
+3. **Configure OIDC Auto-Provision** (even if not using OIDC):
+   - Enable "Auto User Provisioning". You might need to enter a bogus URL to enable it temporarily.
+   - Select the default permissions and libraries for new users.
+4. **Save Settings**
+
+## Example: Caddyfile for Authelia Forward Auth
+
+```caddyfile
+books.example.com {
+  forward_auth authelia:9091 {
+    uri /api/authz/forward-auth
+    copy_headers Remote-User Remote-Name Remote-Email Remote-Groups
+  }
+
+  reverse_proxy booklore:6060
+}
+```


### PR DESCRIPTION
Hi!

This makes Booklore read the default OIDC library attribution preferences (if present) when creating a new user from ForwardAuth, so it doesn't always default to zero libraries.

I'm not familiar enough with Java to be enterprising, so this is as minimal a change as possible.

Boy Scout rule: I've added a mention of Forward Auth in the README, plus some details & examples in a separate doc.