### PR TITLE
Book file formats UI

### DIFF
--- a/booklore-api/build.gradle
+++ b/booklore-api/build.gradle
@@ -78,6 +78,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation "org.mockito:mockito-inline:5.2.0"
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
+    testImplementation 'org.testcontainers:mariadb:1.20.4'
 }
 
 hibernate {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/AdditionalFileController.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.config.security.annotation.CheckBookAccess;
 import com.adityachandel.booklore.model.dto.AdditionalFile;
 import com.adityachandel.booklore.model.enums.AdditionalFileType;
 import com.adityachandel.booklore.service.AdditionalFileService;
+import com.adityachandel.booklore.service.upload.FileUploadService;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import java.util.List;
 public class AdditionalFileController {
 
     private final AdditionalFileService additionalFileService;
+    private final FileUploadService fileUploadService;
 
     @GetMapping
     @CheckBookAccess(bookIdParam = "bookId")
@@ -45,8 +47,7 @@ public class AdditionalFileController {
             @RequestParam("file") MultipartFile file,
             @RequestParam AdditionalFileType additionalFileType,
             @RequestParam(required = false) String description) throws IOException {
-
-        AdditionalFile additionalFile = additionalFileService.addAdditionalFile(bookId, file, additionalFileType, description);
+        AdditionalFile additionalFile = fileUploadService.uploadAdditionalFile(bookId, file, additionalFileType, description);
         return ResponseEntity.ok(additionalFile);
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/AdditionalFileController.java
@@ -1,0 +1,70 @@
+package com.adityachandel.booklore.controller;
+
+import com.adityachandel.booklore.config.security.annotation.CheckBookAccess;
+import com.adityachandel.booklore.model.dto.AdditionalFile;
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import com.adityachandel.booklore.service.AdditionalFileService;
+import lombok.AllArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequestMapping("/api/v1/books/{bookId}/files")
+@RestController
+@AllArgsConstructor
+public class AdditionalFileController {
+
+    private final AdditionalFileService additionalFileService;
+
+    @GetMapping
+    @CheckBookAccess(bookIdParam = "bookId")
+    public ResponseEntity<List<AdditionalFile>> getAdditionalFiles(@PathVariable Long bookId) {
+        List<AdditionalFile> files = additionalFileService.getAdditionalFilesByBookId(bookId);
+        return ResponseEntity.ok(files);
+    }
+
+    @GetMapping(params = "type")
+    @CheckBookAccess(bookIdParam = "bookId")
+    public ResponseEntity<List<AdditionalFile>> getAdditionalFilesByType(
+            @PathVariable Long bookId,
+            @RequestParam AdditionalFileType type) {
+        List<AdditionalFile> files = additionalFileService.getAdditionalFilesByBookIdAndType(bookId, type);
+        return ResponseEntity.ok(files);
+    }
+
+    @PostMapping(consumes = "multipart/form-data")
+    @CheckBookAccess(bookIdParam = "bookId")
+    @PreAuthorize("@securityUtil.canUpload() or @securityUtil.isAdmin()")
+    public ResponseEntity<AdditionalFile> uploadAdditionalFile(
+            @PathVariable Long bookId,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam AdditionalFileType additionalFileType,
+            @RequestParam(required = false) String description) throws IOException {
+
+        AdditionalFile additionalFile = additionalFileService.addAdditionalFile(bookId, file, additionalFileType, description);
+        return ResponseEntity.ok(additionalFile);
+    }
+
+    @GetMapping("/{fileId}/download")
+    @CheckBookAccess(bookIdParam = "bookId")
+    public ResponseEntity<Resource> downloadAdditionalFile(
+            @PathVariable Long bookId,
+            @PathVariable Long fileId) throws IOException {
+        return additionalFileService.downloadAdditionalFile(fileId);
+    }
+
+    @DeleteMapping("/{fileId}")
+    @CheckBookAccess(bookIdParam = "bookId")
+    @PreAuthorize("@securityUtil.canDeleteBook() or @securityUtil.isAdmin()")
+    public ResponseEntity<Void> deleteAdditionalFile(
+            @PathVariable Long bookId,
+            @PathVariable Long fileId) throws IOException {
+        additionalFileService.deleteAdditionalFile(fileId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/mapper/AdditionalFileMapper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/mapper/AdditionalFileMapper.java
@@ -1,0 +1,30 @@
+package com.adityachandel.booklore.mapper;
+
+import com.adityachandel.booklore.model.dto.AdditionalFile;
+import com.adityachandel.booklore.model.entity.BookAdditionalFileEntity;
+import com.adityachandel.booklore.util.FileUtils;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdditionalFileMapper {
+
+    @Mapping(source = "book.id", target = "bookId")
+    @Mapping(source = ".", target = "filePath", qualifiedByName = "mapFilePath")
+    AdditionalFile toAdditionalFile(BookAdditionalFileEntity entity);
+
+    List<AdditionalFile> toAdditionalFiles(List<BookAdditionalFileEntity> entities);
+
+    @Named("mapFilePath")
+    default String mapFilePath(BookAdditionalFileEntity entity) {
+        if (entity == null) return null;
+        try {
+            return entity.getFullFilePath().toString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/mapper/BookMapper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/mapper/BookMapper.java
@@ -1,38 +1,48 @@
 package com.adityachandel.booklore.mapper;
 
+import com.adityachandel.booklore.model.dto.AdditionalFile;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.LibraryPath;
 import com.adityachandel.booklore.model.entity.AuthorEntity;
+import com.adityachandel.booklore.model.entity.BookAdditionalFileEntity;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.CategoryEntity;
 import com.adityachandel.booklore.model.entity.LibraryPathEntity;
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring", uses = {BookMetadataMapper.class, ShelfMapper.class})
+@Mapper(componentModel = "spring", uses = {BookMetadataMapper.class, ShelfMapper.class, AdditionalFileMapper.class})
 public interface BookMapper {
 
     @Mapping(source = "library.id", target = "libraryId")
     @Mapping(source = "libraryPath", target = "libraryPath", qualifiedByName = "mapLibraryPathIdOnly")
     @Mapping(source = "metadata", target = "metadata")
     @Mapping(source = "shelves", target = "shelves")
+    @Mapping(source = "additionalFiles", target = "alternativeFormats", qualifiedByName = "mapAlternativeFormats")
+    @Mapping(source = "additionalFiles", target = "supplementaryFiles", qualifiedByName = "mapSupplementaryFiles")
     Book toBook(BookEntity bookEntity);
 
     @Mapping(source = "library.id", target = "libraryId")
     @Mapping(source = "libraryPath", target = "libraryPath", qualifiedByName = "mapLibraryPathIdOnly")
     @Mapping(source = "metadata", target = "metadata")
     @Mapping(source = "shelves", target = "shelves")
+    @Mapping(source = "additionalFiles", target = "alternativeFormats", qualifiedByName = "mapAlternativeFormats")
+    @Mapping(source = "additionalFiles", target = "supplementaryFiles", qualifiedByName = "mapSupplementaryFiles")
     Book toBookWithDescription(BookEntity bookEntity, @Context boolean includeDescription);
 
     @Mapping(source = "library.id", target = "libraryId")
     @Mapping(source = "libraryPath", target = "libraryPath", qualifiedByName = "mapLibraryPathIdOnly")
     @Mapping(target = "metadata", ignore = true)
     @Mapping(target = "shelves", ignore = true)
+    @Mapping(target = "alternativeFormats", ignore = true)
+    @Mapping(target = "supplementaryFiles", ignore = true)
     Book toBookWithoutMetadataAndShelves(BookEntity bookEntity);
 
     default Set<String> mapAuthors(Set<AuthorEntity> authors) {
@@ -54,6 +64,39 @@ public interface BookMapper {
         if (entity == null) return null;
         return LibraryPath.builder()
                 .id(entity.getId())
+                .build();
+    }
+
+    @Named("mapAlternativeFormats")
+    default List<AdditionalFile> mapAlternativeFormats(List<BookAdditionalFileEntity> additionalFiles) {
+        if (additionalFiles == null) return null;
+        return additionalFiles.stream()
+                .filter(af -> AdditionalFileType.ALTERNATIVE_FORMAT.equals(af.getAdditionalFileType()))
+                .map(this::toAdditionalFile)
+                .toList();
+    }
+
+    @Named("mapSupplementaryFiles")
+    default List<AdditionalFile> mapSupplementaryFiles(List<BookAdditionalFileEntity> additionalFiles) {
+        if (additionalFiles == null) return null;
+        return additionalFiles.stream()
+                .filter(af -> AdditionalFileType.SUPPLEMENTARY.equals(af.getAdditionalFileType()))
+                .map(this::toAdditionalFile)
+                .toList();
+    }
+
+    default AdditionalFile toAdditionalFile(BookAdditionalFileEntity entity) {
+        if (entity == null) return null;
+        return AdditionalFile.builder()
+                .id(entity.getId())
+                .bookId(entity.getBook().getId())
+                .fileName(entity.getFileName())
+                .filePath(entity.getFullFilePath().toString())
+                .fileSubPath(entity.getFileSubPath())
+                .additionalFileType(entity.getAdditionalFileType())
+                .fileSizeKb(entity.getFileSizeKb())
+                .description(entity.getDescription())
+                .addedOn(entity.getAddedOn())
                 .build();
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/AdditionalFile.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/AdditionalFile.java
@@ -1,0 +1,23 @@
+package com.adityachandel.booklore.model.dto;
+
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AdditionalFile {
+    private Long id;
+    private Long bookId;
+    private String fileName;
+    private String filePath;
+    private String fileSubPath;
+    private AdditionalFileType additionalFileType;
+    private Long fileSizeKb;
+    private String description;
+    private Instant addedOn;
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/Book.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/Book.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 
 @Builder
@@ -33,4 +34,6 @@ public class Book {
     private String readStatus;
     private Instant dateFinished;
     private LibraryPath libraryPath;
+    private List<AdditionalFile> alternativeFormats;
+    private List<AdditionalFile> supplementaryFiles;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookAdditionalFileEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookAdditionalFileEntity.java
@@ -1,0 +1,64 @@
+package com.adityachandel.booklore.model.entity;
+
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "book_additional_file")
+public class BookAdditionalFileEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id", nullable = false)
+    private BookEntity book;
+
+    @Column(name = "file_name", length = 1000, nullable = false)
+    private String fileName;
+
+    @Column(name = "file_sub_path", length = 512, nullable = false)
+    private String fileSubPath;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "additional_file_type", nullable = false)
+    private AdditionalFileType additionalFileType;
+
+    @Column(name = "file_size_kb")
+    private Long fileSizeKb;
+
+    @Column(name = "initial_hash", length = 128)
+    private String initialHash;
+
+    @Column(name = "current_hash", length = 128)
+    private String currentHash;
+
+    @Column(name = "alt_format_current_hash", insertable = false, updatable = false)
+    private String altFormatCurrentHash;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "added_on")
+    private Instant addedOn;
+
+    public Path getFullFilePath() {
+        if (book == null || book.getLibraryPath() == null || book.getLibraryPath().getPath() == null
+                || fileSubPath == null || fileName == null) {
+            throw new IllegalStateException("Cannot construct file path: missing book, library path, file subpath, or file name");
+        }
+
+        return Paths.get(book.getLibraryPath().getPath(), fileSubPath, fileName);
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookEntity.java
@@ -10,6 +10,7 @@ import lombok.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -77,6 +78,9 @@ public class BookEntity {
     @Convert(converter = BookRecommendationIdsListConverter.class)
     @Column(name = "similar_books_json", columnDefinition = "TEXT")
     private Set<BookRecommendationLite> similarBooksJson;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<BookAdditionalFileEntity> additionalFiles;
 
     public Path getFullFilePath() {
         if (libraryPath == null || libraryPath.getPath() == null || fileSubPath == null || fileName == null) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/enums/AdditionalFileType.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/enums/AdditionalFileType.java
@@ -1,0 +1,5 @@
+package com.adityachandel.booklore.model.enums;
+
+public enum AdditionalFileType {
+    ALTERNATIVE_FORMAT, SUPPLEMENTARY
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookAdditionalFileRepository.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookAdditionalFileRepository.java
@@ -1,0 +1,41 @@
+package com.adityachandel.booklore.repository;
+
+import com.adityachandel.booklore.model.entity.BookAdditionalFileEntity;
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BookAdditionalFileRepository extends JpaRepository<BookAdditionalFileEntity, Long> {
+
+    List<BookAdditionalFileEntity> findByBookId(Long bookId);
+
+    List<BookAdditionalFileEntity> findByBookIdAndAdditionalFileType(Long bookId, AdditionalFileType additionalFileType);
+
+    /**
+     * Finds a {@link BookAdditionalFileEntity} by its alternative format current hash.
+     * <p>
+     * This method queries against the {@code alt_format_current_hash} virtual column, which is indexed
+     * and only contains values for files where the {@code additional_file_type} is 'ALTERNATIVE_FORMAT'.
+     * This implicitly filters by the file type and provides an efficient lookup.
+     *
+     * @param altFormatCurrentHash The current hash of the file, which is only considered for alternative format files.
+     * @return an {@link Optional} containing the found entity, or an empty {@link Optional} if no match is found.
+     */
+    Optional<BookAdditionalFileEntity> findByAltFormatCurrentHash(String altFormatCurrentHash);
+
+    @Query("SELECT af FROM BookAdditionalFileEntity af WHERE af.book.libraryPath.id = :libraryPathId AND af.fileSubPath = :fileSubPath AND af.fileName = :fileName")
+    Optional<BookAdditionalFileEntity> findByLibraryPath_IdAndFileSubPathAndFileName(@Param("libraryPathId") Long libraryPathId,
+                                                                                      @Param("fileSubPath") String fileSubPath,
+                                                                                      @Param("fileName") String fileName);
+
+    List<BookAdditionalFileEntity> findByAdditionalFileType(AdditionalFileType additionalFileType);
+
+    @Query("SELECT COUNT(af) FROM BookAdditionalFileEntity af WHERE af.book.id = :bookId AND af.additionalFileType = :additionalFileType")
+    long countByBookIdAndAdditionalFileType(@Param("bookId") Long bookId, @Param("additionalFileType") AdditionalFileType additionalFileType);
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
@@ -1,0 +1,145 @@
+package com.adityachandel.booklore.service;
+
+import com.adityachandel.booklore.mapper.AdditionalFileMapper;
+import com.adityachandel.booklore.model.dto.AdditionalFile;
+import com.adityachandel.booklore.model.entity.BookAdditionalFileEntity;
+import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
+import com.adityachandel.booklore.repository.BookRepository;
+import com.adityachandel.booklore.util.FileUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@AllArgsConstructor
+@Service
+public class AdditionalFileService {
+
+    private final BookAdditionalFileRepository additionalFileRepository;
+    private final BookRepository bookRepository;
+    private final AdditionalFileMapper additionalFileMapper;
+
+    public List<AdditionalFile> getAdditionalFilesByBookId(Long bookId) {
+        List<BookAdditionalFileEntity> entities = additionalFileRepository.findByBookId(bookId);
+        return additionalFileMapper.toAdditionalFiles(entities);
+    }
+
+    public List<AdditionalFile> getAdditionalFilesByBookIdAndType(Long bookId, AdditionalFileType type) {
+        List<BookAdditionalFileEntity> entities = additionalFileRepository.findByBookIdAndAdditionalFileType(bookId, type);
+        return additionalFileMapper.toAdditionalFiles(entities);
+    }
+
+    @Transactional
+    public AdditionalFile addAdditionalFile(Long bookId, MultipartFile file, AdditionalFileType additionalFileType, String description) throws IOException {
+        Optional<BookEntity> bookOpt = bookRepository.findById(bookId);
+        if (bookOpt.isEmpty()) {
+            throw new IllegalArgumentException("Book not found with id: " + bookId);
+        }
+
+        BookEntity book = bookOpt.get();
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null) {
+            throw new IllegalArgumentException("File must have a name");
+        }
+
+        // Check for duplicates by hash
+        String fileHash = computeFileHash(file);
+        Optional<BookAdditionalFileEntity> existingFile = additionalFileRepository.findByAltFormatCurrentHash(fileHash);
+        if (existingFile.isPresent()) {
+            throw new IllegalArgumentException("File already exists with same content");
+        }
+
+        // Store file in same directory as the book
+        Path targetPath = Paths.get(book.getLibraryPath().getPath(), book.getFileSubPath(), originalFileName);
+        Files.createDirectories(targetPath.getParent());
+        Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+        // Create entity
+        BookAdditionalFileEntity entity = BookAdditionalFileEntity.builder()
+                .book(book)
+                .fileName(originalFileName)
+                .fileSubPath(book.getFileSubPath())
+                .additionalFileType(additionalFileType)
+                .fileSizeKb(file.getSize() / 1024)
+                .initialHash(fileHash)
+                .currentHash(fileHash)
+                .description(description)
+                .addedOn(Instant.now())
+                .build();
+
+        entity = additionalFileRepository.save(entity);
+        return additionalFileMapper.toAdditionalFile(entity);
+    }
+
+    @Transactional
+    public void deleteAdditionalFile(Long fileId) {
+        Optional<BookAdditionalFileEntity> fileOpt = additionalFileRepository.findById(fileId);
+        if (fileOpt.isEmpty()) {
+            throw new IllegalArgumentException("Additional file not found with id: " + fileId);
+        }
+
+        BookAdditionalFileEntity file = fileOpt.get();
+
+        // Delete physical file
+        try {
+            Files.deleteIfExists(file.getFullFilePath());
+        } catch (IOException e) {
+            log.warn("Failed to delete physical file: {}", file.getFullFilePath(), e);
+        }
+
+        // Delete database record
+        additionalFileRepository.delete(file);
+    }
+
+    public ResponseEntity<Resource> downloadAdditionalFile(Long fileId) throws IOException {
+        Optional<BookAdditionalFileEntity> fileOpt = additionalFileRepository.findById(fileId);
+        if (fileOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        BookAdditionalFileEntity file = fileOpt.get();
+        Path filePath = file.getFullFilePath();
+
+        if (!Files.exists(filePath)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Resource resource = new UrlResource(filePath.toUri());
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+                .body(resource);
+    }
+
+    private String computeFileHash(MultipartFile file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(file.getBytes());
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
@@ -1,5 +1,6 @@
 package com.adityachandel.booklore.service;
 
+import com.adityachandel.booklore.exception.ApiError;
 import com.adityachandel.booklore.mapper.AdditionalFileMapper;
 import com.adityachandel.booklore.model.dto.AdditionalFile;
 import com.adityachandel.booklore.model.entity.BookAdditionalFileEntity;
@@ -7,6 +8,7 @@ import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.enums.AdditionalFileType;
 import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
 import com.adityachandel.booklore.repository.BookRepository;
+import com.adityachandel.booklore.service.monitoring.MonitoringService;
 import com.adityachandel.booklore.util.FileUtils;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -39,6 +42,7 @@ public class AdditionalFileService {
     private final BookAdditionalFileRepository additionalFileRepository;
     private final BookRepository bookRepository;
     private final AdditionalFileMapper additionalFileMapper;
+    private final MonitoringService monitoringService;
 
     public List<AdditionalFile> getAdditionalFilesByBookId(Long bookId) {
         List<BookAdditionalFileEntity> entities = additionalFileRepository.findByBookId(bookId);
@@ -48,48 +52,6 @@ public class AdditionalFileService {
     public List<AdditionalFile> getAdditionalFilesByBookIdAndType(Long bookId, AdditionalFileType type) {
         List<BookAdditionalFileEntity> entities = additionalFileRepository.findByBookIdAndAdditionalFileType(bookId, type);
         return additionalFileMapper.toAdditionalFiles(entities);
-    }
-
-    @Transactional
-    public AdditionalFile addAdditionalFile(Long bookId, MultipartFile file, AdditionalFileType additionalFileType, String description) throws IOException {
-        Optional<BookEntity> bookOpt = bookRepository.findById(bookId);
-        if (bookOpt.isEmpty()) {
-            throw new IllegalArgumentException("Book not found with id: " + bookId);
-        }
-
-        BookEntity book = bookOpt.get();
-        String originalFileName = file.getOriginalFilename();
-        if (originalFileName == null) {
-            throw new IllegalArgumentException("File must have a name");
-        }
-
-        // Check for duplicates by hash
-        String fileHash = computeFileHash(file);
-        Optional<BookAdditionalFileEntity> existingFile = additionalFileRepository.findByAltFormatCurrentHash(fileHash);
-        if (existingFile.isPresent()) {
-            throw new IllegalArgumentException("File already exists with same content");
-        }
-
-        // Store file in same directory as the book
-        Path targetPath = Paths.get(book.getLibraryPath().getPath(), book.getFileSubPath(), originalFileName);
-        Files.createDirectories(targetPath.getParent());
-        Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
-
-        // Create entity
-        BookAdditionalFileEntity entity = BookAdditionalFileEntity.builder()
-                .book(book)
-                .fileName(originalFileName)
-                .fileSubPath(book.getFileSubPath())
-                .additionalFileType(additionalFileType)
-                .fileSizeKb(file.getSize() / 1024)
-                .initialHash(fileHash)
-                .currentHash(fileHash)
-                .description(description)
-                .addedOn(Instant.now())
-                .build();
-
-        entity = additionalFileRepository.save(entity);
-        return additionalFileMapper.toAdditionalFile(entity);
     }
 
     @Transactional
@@ -131,15 +93,5 @@ public class AdditionalFileService {
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
                 .body(resource);
-    }
-
-    private String computeFileHash(MultipartFile file) throws IOException {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hashBytes = digest.digest(file.getBytes());
-            return HexFormat.of().formatHex(hashBytes);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 algorithm not available", e);
-        }
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/AbstractFileProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/AbstractFileProcessor.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.mapper.BookMapper;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.BookCreatorService;
@@ -21,18 +22,18 @@ import java.util.Optional;
 public abstract class AbstractFileProcessor implements BookFileProcessor {
 
     protected final BookRepository bookRepository;
+    protected final BookAdditionalFileRepository bookAdditionalFileRepository;
     protected final BookCreatorService bookCreatorService;
     protected final BookMapper bookMapper;
     protected final FileProcessingUtils fileProcessingUtils;
-    protected final BookMetadataRepository bookMetadataRepository;
     protected final MetadataMatchService metadataMatchService;
 
-    protected AbstractFileProcessor(BookRepository bookRepository, BookCreatorService bookCreatorService, BookMapper bookMapper, FileProcessingUtils fileProcessingUtils, BookMetadataRepository bookMetadataRepository, MetadataMatchService metadataMatchService) {
+    protected AbstractFileProcessor(BookRepository bookRepository, BookAdditionalFileRepository bookAdditionalFileRepository, BookCreatorService bookCreatorService, BookMapper bookMapper, FileProcessingUtils fileProcessingUtils, MetadataMatchService metadataMatchService) {
         this.bookRepository = bookRepository;
+        this.bookAdditionalFileRepository = bookAdditionalFileRepository;
         this.bookCreatorService = bookCreatorService;
         this.bookMapper = bookMapper;
         this.fileProcessingUtils = fileProcessingUtils;
-        this.bookMetadataRepository = bookMetadataRepository;
         this.metadataMatchService = metadataMatchService;
     }
 
@@ -43,7 +44,7 @@ public abstract class AbstractFileProcessor implements BookFileProcessor {
         String fileName = path.getFileName().toString();
         String hash = FileFingerprint.generateHash(path);
 
-        Optional<Book> duplicate = fileProcessingUtils.checkForDuplicateAndUpdateMetadataIfNeeded(libraryFile, hash, bookRepository, bookMapper);
+        Optional<Book> duplicate = fileProcessingUtils.checkForDuplicateAndUpdateMetadataIfNeeded(libraryFile, hash, bookRepository, bookAdditionalFileRepository, bookMapper);
         if (duplicate.isPresent()) {
             return handleDuplicate(duplicate.get(), libraryFile);
         }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.mapper.BookMapper;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.enums.BookFileType;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.BookCreatorService;
@@ -31,12 +32,13 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
     private final BookMetadataRepository bookMetadataRepository;
 
     public CbxProcessor(BookRepository bookRepository,
+                        BookAdditionalFileRepository bookAdditionalFileRepository,
                         BookCreatorService bookCreatorService,
                         BookMapper bookMapper,
                         FileProcessingUtils fileProcessingUtils,
                         BookMetadataRepository bookMetadataRepository,
                         MetadataMatchService metadataMatchService) {
-        super(bookRepository, bookCreatorService, bookMapper, fileProcessingUtils, bookMetadataRepository, metadataMatchService);
+        super(bookRepository, bookAdditionalFileRepository, bookCreatorService, bookMapper, fileProcessingUtils, metadataMatchService);
         this.bookMetadataRepository = bookMetadataRepository;
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
@@ -6,6 +6,7 @@ import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.BookMetadataEntity;
 import com.adityachandel.booklore.model.enums.BookFileType;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.BookCreatorService;
@@ -35,13 +36,14 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
     private final BookMetadataRepository bookMetadataRepository;
 
     public EpubProcessor(BookRepository bookRepository,
+                         BookAdditionalFileRepository bookAdditionalFileRepository,
                          BookCreatorService bookCreatorService,
                          BookMapper bookMapper,
                          FileProcessingUtils fileProcessingUtils,
                          BookMetadataRepository bookMetadataRepository,
                          MetadataMatchService metadataMatchService,
                          EpubMetadataExtractor epubMetadataExtractor) {
-        super(bookRepository, bookCreatorService, bookMapper, fileProcessingUtils, bookMetadataRepository, metadataMatchService);
+        super(bookRepository, bookAdditionalFileRepository, bookCreatorService, bookMapper, fileProcessingUtils, metadataMatchService);
         this.epubMetadataExtractor = epubMetadataExtractor;
         this.bookMetadataRepository = bookMetadataRepository;
     }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
@@ -5,6 +5,7 @@ import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.enums.BookFileType;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.BookCreatorService;
@@ -35,13 +36,14 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
     private final BookMetadataRepository bookMetadataRepository;
 
     public PdfProcessor(BookRepository bookRepository,
+                        BookAdditionalFileRepository bookAdditionalFileRepository,
                         BookCreatorService bookCreatorService,
                         BookMapper bookMapper,
                         FileProcessingUtils fileProcessingUtils,
                         BookMetadataRepository bookMetadataRepository,
                         MetadataMatchService metadataMatchService,
                         PdfMetadataExtractor pdfMetadataExtractor) {
-        super(bookRepository, bookCreatorService, bookMapper, fileProcessingUtils, bookMetadataRepository, metadataMatchService);
+        super(bookRepository, bookAdditionalFileRepository, bookCreatorService, bookMapper, fileProcessingUtils, metadataMatchService);
         this.pdfMetadataExtractor = pdfMetadataExtractor;
         this.bookMetadataRepository = bookMetadataRepository;
     }

--- a/booklore-api/src/main/resources/db/migration/V44__Create_book_additional_file_table.sql
+++ b/booklore-api/src/main/resources/db/migration/V44__Create_book_additional_file_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS book_additional_file
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    book_id              BIGINT       NOT NULL,
+    file_name            VARCHAR(1000) NOT NULL,
+    file_sub_path        VARCHAR(512) NOT NULL,
+    additional_file_type ENUM('ALTERNATIVE_FORMAT', 'SUPPLEMENTARY') NOT NULL,
+    file_size_kb         BIGINT,
+    initial_hash         VARCHAR(128),
+    current_hash         VARCHAR(128),
+    description          TEXT,
+    added_on             TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- Virtual column for alternative format files
+    alt_format_current_hash     VARCHAR(128) AS (CASE WHEN additional_file_type = 'ALTERNATIVE_FORMAT' THEN current_hash END) STORED,
+
+    CONSTRAINT fk_book_additional_file_book FOREIGN KEY (book_id) REFERENCES book (id) ON DELETE CASCADE,
+    UNIQUE INDEX idx_book_additional_file_current_hash_alt_format (alt_format_current_hash)
+);
+
+CREATE INDEX idx_book_additional_file_book_id ON book_additional_file(book_id);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/repository/BookAdditionalFileRepositoryTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/repository/BookAdditionalFileRepositoryTest.java
@@ -1,0 +1,384 @@
+package com.adityachandel.booklore.repository;
+
+import com.adityachandel.booklore.model.entity.*;
+import com.adityachandel.booklore.model.enums.AdditionalFileType;
+import com.adityachandel.booklore.model.enums.BookFileType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for BookAdditionalFileRepository using TestContainers with MariaDB.
+ * This provides real database testing with the same database engine used in production.
+ */
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookAdditionalFileRepositoryTest {
+
+    @Container
+    static MariaDBContainer<?> mariaDB = new MariaDBContainer<>("mariadb:11.4.5")
+            .withDatabaseName("booklore_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariaDB::getJdbcUrl);
+        registry.add("spring.datasource.username", mariaDB::getUsername);
+        registry.add("spring.datasource.password", mariaDB::getPassword);
+        registry.add("spring.datasource.driver-class-name", mariaDB::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.flyway.clean-disabled", () -> "false");
+        registry.add("spring.flyway.baseline-on-migrate", () -> "true");
+    }
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private BookAdditionalFileRepository additionalFileRepository;
+
+    private BookEntity testBook;
+    private LibraryEntity testLibrary;
+    private LibraryPathEntity testLibraryPath;
+
+    @BeforeEach
+    void setUp() {
+        // Create test library
+        testLibrary = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .watch(false)
+                .build();
+        testLibrary = entityManager.persistAndFlush(testLibrary);
+
+        // Create test library path
+        testLibraryPath = LibraryPathEntity.builder()
+                .path("/test/path")
+                .library(testLibrary)
+                .build();
+        testLibraryPath = entityManager.persistAndFlush(testLibraryPath);
+
+        // Create test book
+        testBook = BookEntity.builder()
+                .fileName("test-book.pdf")
+                .fileSubPath("subfolder")
+                .bookType(BookFileType.PDF)
+                .fileSizeKb(1024L)
+                .library(testLibrary)
+                .libraryPath(testLibraryPath)
+                .addedOn(Instant.now())
+                .initialHash("initial-hash")
+                .currentHash("current-hash")
+                .deleted(false)
+                .build();
+        testBook = entityManager.persistAndFlush(testBook);
+    }
+
+    @Test
+    void shouldSaveAndFindAdditionalFile() {
+        // Given
+        BookAdditionalFileEntity additionalFile = BookAdditionalFileEntity.builder()
+                .book(testBook)
+                .fileName("source-code.zip")
+                .fileSubPath("subfolder")
+                .additionalFileType(AdditionalFileType.SUPPLEMENTARY)
+                .fileSizeKb(512L)
+                .initialHash("zip-initial-hash")
+                .currentHash("zip-current-hash")
+                .description("Source code archive")
+                .addedOn(Instant.now())
+                .build();
+
+        // When
+        BookAdditionalFileEntity saved = additionalFileRepository.saveAndFlush(additionalFile);
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository.findById(saved.getId());
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getFileName()).isEqualTo("source-code.zip");
+        assertThat(found.get().getAdditionalFileType()).isEqualTo(AdditionalFileType.SUPPLEMENTARY);
+        assertThat(found.get().getBook().getId()).isEqualTo(testBook.getId());
+        assertThat(found.get().getFileSizeKb()).isEqualTo(512L);
+        assertThat(found.get().getDescription()).isEqualTo("Source code archive");
+    }
+
+    @Test
+    void shouldFindAdditionalFilesByBookId() {
+        // Given
+        BookAdditionalFileEntity file1 = createAdditionalFile("file1.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity file2 = createAdditionalFile("file2.epub", AdditionalFileType.ALTERNATIVE_FORMAT);
+        entityManager.persistAndFlush(file1);
+        entityManager.persistAndFlush(file2);
+
+        // When
+        List<BookAdditionalFileEntity> files = additionalFileRepository.findByBookId(testBook.getId());
+
+        // Then
+        assertThat(files).hasSize(2);
+        assertThat(files).extracting(BookAdditionalFileEntity::getFileName)
+                .containsExactlyInAnyOrder("file1.zip", "file2.epub");
+    }
+
+    @Test
+    void shouldFindAdditionalFilesByBookIdAndType() {
+        // Given
+        BookAdditionalFileEntity supplementaryFile = createAdditionalFile("source.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity alternativeFile = createAdditionalFile("book.epub", AdditionalFileType.ALTERNATIVE_FORMAT);
+        entityManager.persistAndFlush(supplementaryFile);
+        entityManager.persistAndFlush(alternativeFile);
+
+        // When - Find supplementary files
+        List<BookAdditionalFileEntity> supplementaryFiles = additionalFileRepository
+                .findByBookIdAndAdditionalFileType(testBook.getId(), AdditionalFileType.SUPPLEMENTARY);
+
+        // When - Find alternative format files
+        List<BookAdditionalFileEntity> alternativeFiles = additionalFileRepository
+                .findByBookIdAndAdditionalFileType(testBook.getId(), AdditionalFileType.ALTERNATIVE_FORMAT);
+
+        // Then
+        assertThat(supplementaryFiles).hasSize(1);
+        assertThat(supplementaryFiles.get(0).getFileName()).isEqualTo("source.zip");
+
+        assertThat(alternativeFiles).hasSize(1);
+        assertThat(alternativeFiles.get(0).getFileName()).isEqualTo("book.epub");
+    }
+
+    @Test
+    void shouldFindAdditionalFileByCurrentHash() {
+        // Given
+        String uniqueHash = "unique-hash-123";
+        BookAdditionalFileEntity file = createAdditionalFile("test.pdf", AdditionalFileType.ALTERNATIVE_FORMAT);
+        file.setCurrentHash(uniqueHash);
+        entityManager.persistAndFlush(file);
+
+        // When
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository.findByAltFormatCurrentHash(uniqueHash);
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getCurrentHash()).isEqualTo(uniqueHash);
+        assertThat(found.get().getFileName()).isEqualTo("test.pdf");
+    }
+
+    @Test
+    void shouldNotFindAdditionalFileByNonExistentHash() {
+        // When
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository.findByAltFormatCurrentHash("non-existent-hash");
+
+        // Then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void shouldFindByLibraryPathAndFileSubPathAndFileName() {
+        // Given
+        BookAdditionalFileEntity file = createAdditionalFile("specific-file.zip", AdditionalFileType.SUPPLEMENTARY);
+        entityManager.persistAndFlush(file);
+
+        // When
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository
+                .findByLibraryPath_IdAndFileSubPathAndFileName(
+                        testLibraryPath.getId(),
+                        "subfolder",
+                        "specific-file.zip"
+                );
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getFileName()).isEqualTo("specific-file.zip");
+    }
+
+    @Test
+    void shouldCountAdditionalFilesByBookIdAndType() {
+        // Given
+        BookAdditionalFileEntity supplementary1 = createAdditionalFile("supp1.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity supplementary2 = createAdditionalFile("supp2.tar", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity alternative1 = createAdditionalFile("alt1.epub", AdditionalFileType.ALTERNATIVE_FORMAT);
+        entityManager.persistAndFlush(supplementary1);
+        entityManager.persistAndFlush(supplementary2);
+        entityManager.persistAndFlush(alternative1);
+
+        // When
+        long supplementaryCount = additionalFileRepository
+                .countByBookIdAndAdditionalFileType(testBook.getId(), AdditionalFileType.SUPPLEMENTARY);
+        long alternativeCount = additionalFileRepository
+                .countByBookIdAndAdditionalFileType(testBook.getId(), AdditionalFileType.ALTERNATIVE_FORMAT);
+
+        // Then
+        assertThat(supplementaryCount).isEqualTo(2);
+        assertThat(alternativeCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldFindAdditionalFilesByType() {
+        // Given
+        BookAdditionalFileEntity supplementaryFile = createAdditionalFile("supp.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity alternativeFile = createAdditionalFile("alt.epub", AdditionalFileType.ALTERNATIVE_FORMAT);
+        entityManager.persistAndFlush(supplementaryFile);
+        entityManager.persistAndFlush(alternativeFile);
+
+        // When
+        List<BookAdditionalFileEntity> supplementaryFiles = additionalFileRepository
+                .findByAdditionalFileType(AdditionalFileType.SUPPLEMENTARY);
+
+        // Then
+        assertThat(supplementaryFiles).hasSize(1);
+        assertThat(supplementaryFiles.get(0).getAdditionalFileType()).isEqualTo(AdditionalFileType.SUPPLEMENTARY);
+    }
+
+    @Test
+    void shouldDeleteAdditionalFile() {
+        // Given
+        BookAdditionalFileEntity file = createAdditionalFile("to-delete.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity saved = entityManager.persistAndFlush(file);
+        Long fileId = saved.getId();
+
+        // When
+        additionalFileRepository.delete(saved);
+        entityManager.flush();
+
+        // Then
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository.findById(fileId);
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void shouldCascadeDeleteWhenBookIsDeleted() {
+        // Given - Create and persist an additional file first
+        BookAdditionalFileEntity file = createAdditionalFile("cascade-test.zip", AdditionalFileType.SUPPLEMENTARY);
+        entityManager.persistAndFlush(file);
+        Long fileId = file.getId();
+        Long bookId = testBook.getId();
+
+        // Clear the persistence context to ensure clean state
+        entityManager.clear();
+
+        // When - Delete the book (should cascade to additional files)
+        BookEntity bookToDelete = entityManager.find(BookEntity.class, bookId);
+        entityManager.remove(bookToDelete);
+        entityManager.flush();
+
+        // Then
+        Optional<BookAdditionalFileEntity> found = additionalFileRepository.findById(fileId);
+        assertThat(found).isEmpty();
+
+        // Also verify the book is deleted
+        BookEntity deletedBook = entityManager.find(BookEntity.class, bookId);
+        assertThat(deletedBook).isNull();
+    }
+
+    @Test
+    void shouldReturnEmptyListForNonExistentBookId() {
+        // When
+        List<BookAdditionalFileEntity> files = additionalFileRepository.findByBookId(99999L);
+
+        // Then
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    void shouldHandleMultipleFilesWithSameTypeForOneBook() {
+        // Given - Multiple supplementary files for the same book
+        BookAdditionalFileEntity file1 = createAdditionalFile("code.zip", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity file2 = createAdditionalFile("docs.tar.gz", AdditionalFileType.SUPPLEMENTARY);
+        BookAdditionalFileEntity file3 = createAdditionalFile("samples.rar", AdditionalFileType.SUPPLEMENTARY);
+        entityManager.persistAndFlush(file1);
+        entityManager.persistAndFlush(file2);
+        entityManager.persistAndFlush(file3);
+
+        // When
+        List<BookAdditionalFileEntity> supplementaryFiles = additionalFileRepository
+                .findByBookIdAndAdditionalFileType(testBook.getId(), AdditionalFileType.SUPPLEMENTARY);
+
+        // Then
+        assertThat(supplementaryFiles).hasSize(3);
+        assertThat(supplementaryFiles).extracting(BookAdditionalFileEntity::getFileName)
+                .containsExactlyInAnyOrder("code.zip", "docs.tar.gz", "samples.rar");
+    }
+
+    @Test
+    void shouldTestUniqueConstraintsAndDuplicateHashes() {
+        // Given - Two files with same hash (simulating duplicate content)
+        BookAdditionalFileEntity file1 = createAdditionalFile("original.zip", AdditionalFileType.SUPPLEMENTARY);
+        file1.setCurrentHash("duplicate-hash");
+        entityManager.persistAndFlush(file1);
+
+        BookAdditionalFileEntity file2 = createAdditionalFile("copy.zip", AdditionalFileType.SUPPLEMENTARY);
+        file2.setCurrentHash("duplicate-hash");
+        entityManager.persistAndFlush(file2);
+
+        // When
+        List<BookAdditionalFileEntity> filesWithSameHash = additionalFileRepository
+                .findByBookId(testBook.getId()).stream()
+                .filter(f -> "duplicate-hash".equals(f.getCurrentHash()))
+                .toList();
+
+        // Then - Both files exist (no unique constraint on hash at DB level)
+        assertThat(filesWithSameHash).hasSize(2);
+        assertThat(filesWithSameHash).extracting(BookAdditionalFileEntity::getFileName)
+                .containsExactlyInAnyOrder("original.zip", "copy.zip");
+    }
+
+    @Test
+    void shouldTestFilePathConstruction() {
+        // Given
+        BookAdditionalFileEntity file = createAdditionalFile("path-test.zip", AdditionalFileType.SUPPLEMENTARY);
+        entityManager.persistAndFlush(file);
+
+        // When
+        String fullPath = file.getFullFilePath().toString();
+
+        // Then
+        // Use File.separator to handle both Windows and Unix paths
+        assertThat(fullPath).contains("test" + File.separator + "path");
+        assertThat(fullPath).contains("subfolder");
+        assertThat(fullPath).contains("path-test.zip");
+    }
+
+    @Test
+    void shouldPersistAndRetrieveTimestamps() {
+        // Given
+        Instant beforeSave = Instant.now().minusSeconds(1);
+        BookAdditionalFileEntity file = createAdditionalFile("timestamp-test.zip", AdditionalFileType.SUPPLEMENTARY);
+        Instant afterSave = Instant.now().plusSeconds(1);
+
+        // When
+        BookAdditionalFileEntity saved = entityManager.persistAndFlush(file);
+
+        // Then
+        assertThat(saved.getAddedOn()).isNotNull();
+        assertThat(saved.getAddedOn()).isBetween(beforeSave, afterSave);
+    }
+
+    private BookAdditionalFileEntity createAdditionalFile(String fileName, AdditionalFileType type) {
+        return BookAdditionalFileEntity.builder()
+                .book(testBook)
+                .fileName(fileName)
+                .fileSubPath("subfolder")
+                .additionalFileType(type)
+                .fileSizeKb(256L)
+                .initialHash("initial-" + fileName)
+                .currentHash("current-" + fileName)
+                .description("Test file: " + fileName)
+                .addedOn(Instant.now())
+                .build();
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/upload/FileUploadServiceTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/upload/FileUploadServiceTest.java
@@ -3,12 +3,15 @@ package com.adityachandel.booklore.service.upload;
 import com.adityachandel.booklore.config.AppProperties;
 import com.adityachandel.booklore.exception.APIException;
 import com.adityachandel.booklore.exception.ApiError;
+import com.adityachandel.booklore.mapper.AdditionalFileMapperImpl;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.AppSettings;
 import com.adityachandel.booklore.model.entity.LibraryEntity;
 import com.adityachandel.booklore.model.entity.LibraryPathEntity;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.model.websocket.Topic;
+import com.adityachandel.booklore.repository.BookAdditionalFileRepository;
+import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.repository.LibraryRepository;
 import com.adityachandel.booklore.service.NotificationService;
 import com.adityachandel.booklore.service.appsettings.AppSettingService;
@@ -45,6 +48,10 @@ class FileUploadServiceTest {
     @Mock
     LibraryRepository libraryRepository;
     @Mock
+    BookRepository bookRepository;
+    @Mock
+    BookAdditionalFileRepository bookAdditionalFileRepository;
+    @Mock
     BookFileProcessorRegistry processorRegistry;
     @Mock
     NotificationService notificationService;
@@ -71,10 +78,13 @@ class FileUploadServiceTest {
         settings.setUploadPattern("{currentFilename}");
         when(appSettingService.getAppSettings()).thenReturn(settings);
 
+        var additionalFilesMapper = new AdditionalFileMapperImpl();
+
         service = new FileUploadService(
-                libraryRepository, processorRegistry, notificationService,
+                libraryRepository, bookRepository, bookAdditionalFileRepository,
+                processorRegistry, notificationService,
                 appSettingService, appProperties, pdfMetadataExtractor,
-                epubMetadataExtractor, monitoringService
+                epubMetadataExtractor, additionalFilesMapper, monitoringService
         );
 
         ReflectionTestUtils.setField(service, "userId", "0");

--- a/booklore-ui/package-lock.json
+++ b/booklore-ui/package-lock.json
@@ -21,6 +21,7 @@
         "@stomp/rx-stomp": "^2.0.1",
         "@stomp/stompjs": "^7.1.1",
         "@tailwindcss/postcss": "^4.1.8",
+        "@tweenjs/tween.js": "^25.0.0",
         "angular-oauth2-oidc": "^20.0.0",
         "epubjs": "^0.3.93",
         "jwt-decode": "^4.0.0",
@@ -34,6 +35,7 @@
         "showdown": "^2.1.0",
         "tailwindcss-primeui": "^0.6.1",
         "tslib": "^2.8.1",
+        "uuid": "^11.1.0",
         "ws": "^8.18.2",
         "zone.js": "^0.15.1"
       },

--- a/booklore-ui/package.json
+++ b/booklore-ui/package.json
@@ -25,6 +25,7 @@
     "@stomp/rx-stomp": "^2.0.1",
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/postcss": "^4.1.8",
+    "@tweenjs/tween.js": "^25.0.0",
     "angular-oauth2-oidc": "^20.0.0",
     "epubjs": "^0.3.93",
     "jwt-decode": "^4.0.0",
@@ -38,6 +39,7 @@
     "showdown": "^2.1.0",
     "tailwindcss-primeui": "^0.6.1",
     "tslib": "^2.8.1",
+    "uuid": "^11.1.0",
     "ws": "^8.18.2",
     "zone.js": "^0.15.1"
   },

--- a/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.html
+++ b/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.html
@@ -1,0 +1,130 @@
+<div class="flex flex-col gap-6 p-4 items-center justify-center w-full max-w-[700px]">
+  <!-- Book Information -->
+  <div class="w-full text-center">
+    <h3 class="text-lg font-semibold mb-2">{{ book.metadata?.title || 'Unknown Title' }}</h3>
+    <p class="text-sm text-gray-600">{{ book.filePath }}</p>
+  </div>
+
+  <!-- File Type Selection -->
+  <p-dropdown
+    [options]="fileTypeOptions"
+    [(ngModel)]="fileType"
+    optionLabel="label"
+    optionValue="value"
+    placeholder="Select file type"
+    class="w-full"
+    [disabled]="isUploading"
+  ></p-dropdown>
+
+  <!-- Description Field -->
+  <div class="w-full">
+    <label for="description" class="block text-sm font-medium mb-2">Description (Optional)</label>
+    <textarea
+      pInputTextarea
+      [(ngModel)]="description"
+      rows="3"
+      placeholder="Add a description for this file..."
+      class="w-full"
+      [disabled]="isUploading"
+    ></textarea>
+  </div>
+
+  <!-- File Upload -->
+  <p-fileupload class="w-full" name="file"
+    [maxFileSize]="maxFileSizeBytes"
+    [customUpload]="true"
+    [multiple]="false"
+    (onSelect)="onFilesSelect($event)"
+    (uploadHandler)="uploadFiles($event)"
+    [disabled]="isUploading">
+    <ng-template #header let-files let-chooseCallback="chooseCallback" let-clearCallback="clearCallback" let-uploadCallback="uploadCallback">
+      <div class="flex flex-wrap items-center justify-center flex-1 gap-4">
+        <div class="flex gap-4">
+          <p-button (onClick)="choose($event, chooseCallback)"
+            icon="pi pi-images"
+            [rounded]="true"
+            [outlined]="true"
+            [disabled]="isChooseDisabled()"/>
+          <p-button (onClick)="uploadEvent(uploadCallback)"
+            icon="pi pi-cloud-upload"
+            [rounded]="true"
+            [outlined]="true"
+            severity="success"
+            [disabled]="isUploadDisabled()"/>
+          <p-button (onClick)="onClear(clearCallback)"
+            icon="pi pi-times"
+            [rounded]="true"
+            [outlined]="true"
+            severity="danger"
+            [disabled]="!filesPresent() || isUploading"/>
+        </div>
+      </div>
+    </ng-template>
+    <ng-template #content let-files let-removeFileCallback="removeFileCallback">
+      <div class="flex flex-col gap-8 px-4">
+        @if (files?.length > 0) {
+          <div>
+            <div class="max-h-96 max-w-[22rem] md:max-w-none overflow-y-auto pr-2">
+              <div class="flex flex-wrap">
+                @for (uploadFile of this.files; track uploadFile; let i = $index) {
+                  <div class="flex justify-between items-center w-full gap-4">
+                    <div class="flex items-center gap-4 overflow-hidden flex-1">
+                      <p-badge [value]="uploadFile.status" [severity]="getBadgeSeverity(uploadFile.status)" class="shrink-0"/>
+                      <span class="font-semibold text-ellipsis whitespace-nowrap overflow-hidden flex-1">
+                        {{ uploadFile.file.name }}
+                      </span>
+                      <div class="shrink-0">{{ formatSize(uploadFile.file.size) }}</div>
+                    </div>
+                    @switch (uploadFile.status) {
+                      @case ('Pending') {
+                        <p-button
+                          icon="pi pi-times"
+                          (click)="onRemoveTemplatingFile($event, uploadFile.file, removeFileCallback, i)"
+                          severity="danger"
+                          [text]="true"/>
+                      }
+                      @case ('Uploading') {
+                        <i
+                          class="pi pi-spin pi-spinner p-3"
+                          style="color: slateblue"
+                          pTooltip="Uploading"
+                          tooltipPosition="top">
+                        </i>
+                      }
+                      @case ('Uploaded') {
+                        <i
+                          class="pi pi-check p-3"
+                          style="color: green"
+                          pTooltip="Uploaded"
+                          tooltipPosition="top">
+                        </i>
+                      }
+                      @case ('Failed') {
+                        <i
+                          class="pi pi-exclamation-triangle p-3"
+                          style="color: darkred"
+                          pTooltip="{{ uploadFile.errorMessage || 'Upload failed' }}"
+                          tooltipPosition="top">
+                        </i>
+                      }
+                    }
+                  </div>
+                }
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    </ng-template>
+    <ng-template #file></ng-template>
+    <ng-template #empty>
+      <div class="flex items-center justify-center flex-col text-center">
+        <i class="pi pi-cloud-upload !border-2 !rounded-full !p-8 !text-4xl !text-muted-color"></i>
+        <p class="mt-6 mb-2">Drag and drop a file here to upload.</p>
+        <p class="mt-2 mb-2">
+          Upload an additional file for <strong>{{ book.metadata?.title || 'this book' }}</strong>.
+        </p>
+      </div>
+    </ng-template>
+  </p-fileupload>
+</div>

--- a/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.scss
+++ b/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.scss
@@ -1,0 +1,3 @@
+:host ::ng-deep .p-fileupload-content p-progressbar {
+  display: none !important;
+}

--- a/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.ts
+++ b/booklore-ui/src/app/book/components/additional-file-uploader/additional-file-uploader.component.ts
@@ -1,0 +1,193 @@
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DynamicDialogRef, DynamicDialogConfig } from 'primeng/dynamicdialog';
+import { DropdownModule } from 'primeng/dropdown';
+import { InputTextarea } from 'primeng/inputtextarea';
+import { ButtonModule } from 'primeng/button';
+import { MessageModule } from 'primeng/message';
+import { FileSelectEvent, FileUpload, FileUploadHandlerEvent } from 'primeng/fileupload';
+import { Badge } from 'primeng/badge';
+import { Tooltip } from 'primeng/tooltip';
+import { Subject, takeUntil } from 'rxjs';
+import { BookService } from '../../service/book.service';
+import { AppSettingsService } from '../../../core/service/app-settings.service';
+import { Book, AdditionalFileType } from '../../model/book.model';
+import { MessageService } from 'primeng/api';
+import { filter, take } from 'rxjs/operators';
+
+interface FileTypeOption {
+  label: string;
+  value: AdditionalFileType;
+}
+
+interface UploadingFile {
+  file: File;
+  status: 'Pending' | 'Uploading' | 'Uploaded' | 'Failed';
+  errorMessage?: string;
+}
+
+@Component({
+  selector: 'app-additional-file-uploader',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    DropdownModule,
+    InputTextarea,
+    ButtonModule,
+    MessageModule,
+    FileUpload,
+    Badge,
+    Tooltip
+  ],
+  templateUrl: './additional-file-uploader.component.html',
+  styleUrls: ['./additional-file-uploader.component.scss']
+})
+export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
+  book!: Book;
+  files: UploadingFile[] = [];
+  fileType: AdditionalFileType = AdditionalFileType.ALTERNATIVE_FORMAT;
+  description: string = '';
+  isUploading = false;
+  maxFileSizeBytes?: number;
+
+  fileTypeOptions: FileTypeOption[] = [
+    { label: 'Alternative Format', value: AdditionalFileType.ALTERNATIVE_FORMAT },
+    { label: 'Supplementary File', value: AdditionalFileType.SUPPLEMENTARY }
+  ];
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private dialogRef: DynamicDialogRef,
+    private config: DynamicDialogConfig,
+    private bookService: BookService,
+    private appSettingsService: AppSettingsService,
+    private messageService: MessageService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.book = this.config.data.book;
+    this.appSettingsService.appSettings$
+      .pipe(
+        filter(settings => settings != null),
+        take(1)
+      )
+      .subscribe(settings => {
+        if (settings) {
+          this.maxFileSizeBytes = (settings.maxFileUploadSizeInMb || 100) * 1024 * 1024;
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  hasPendingFiles(): boolean {
+    return this.files.some(f => f.status === 'Pending');
+  }
+
+  filesPresent(): boolean {
+    return this.files.length > 0;
+  }
+
+  choose(_event: any, chooseCallback: () => void): void {
+    chooseCallback();
+  }
+
+  onClear(clearCallback: () => void): void {
+    clearCallback();
+    this.files = [];
+  }
+
+  onFilesSelect(event: FileSelectEvent): void {
+    const newFiles = event.currentFiles;
+    // Only take the first file for single file upload
+    if (newFiles.length > 0) {
+      const file = newFiles[0];
+      this.files = [{
+        file,
+        status: 'Pending'
+      }];
+    }
+  }
+
+  onRemoveTemplatingFile(_event: any, _file: File, removeFileCallback: (event: any, index: number) => void, index: number): void {
+    removeFileCallback(_event, index);
+  }
+
+  uploadEvent(uploadCallback: () => void): void {
+    uploadCallback();
+  }
+
+  uploadFiles(event: FileUploadHandlerEvent): void {
+    const filesToUpload = this.files.filter(f => f.status === 'Pending');
+
+    if (filesToUpload.length === 0) return;
+
+    this.isUploading = true;
+    let pending = filesToUpload.length;
+
+    for (const uploadFile of filesToUpload) {
+      uploadFile.status = 'Uploading';
+
+      this.bookService.uploadAdditionalFile(
+        this.book.id,
+        uploadFile.file,
+        this.fileType,
+        this.description || undefined
+      ).subscribe({
+        next: () => {
+          uploadFile.status = 'Uploaded';
+          if (--pending === 0) {
+            this.isUploading = false;
+            this.dialogRef.close({ success: true });
+          }
+        },
+        error: (err) => {
+          uploadFile.status = 'Failed';
+          uploadFile.errorMessage = err?.error?.message || 'Upload failed due to unknown error.';
+          console.error('Upload failed for', uploadFile.file.name, err);
+          if (--pending === 0) {
+            this.isUploading = false;
+          }
+        }
+      });
+    }
+  }
+
+  isChooseDisabled(): boolean {
+    return this.isUploading;
+  }
+
+  isUploadDisabled(): boolean {
+    return this.isChooseDisabled() || !this.filesPresent() || !this.hasPendingFiles();
+  }
+
+  formatSize(bytes: number): string {
+    const k = 1024;
+    const dm = 2;
+    if (bytes < k) return `${bytes} B`;
+    if (bytes < k * k) return `${(bytes / k).toFixed(dm)} KB`;
+    return `${(bytes / (k * k)).toFixed(dm)} MB`;
+  }
+
+  getBadgeSeverity(status: UploadingFile['status']): 'info' | 'warn' | 'success' | 'danger' {
+    switch (status) {
+      case 'Pending':
+        return 'warn';
+      case 'Uploading':
+        return 'info';
+      case 'Uploaded':
+        return 'success';
+      case 'Failed':
+        return 'danger';
+      default:
+        return 'info';
+    }
+  }
+}

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
@@ -72,7 +72,7 @@
         class="custom-button-padding"
         size="small"
         [text]="true"
-        (click)="menu.toggle($event)"
+        (click)="onMenuToggle($event, menu)"
         icon="pi pi-ellipsis-v">
       </p-button>
     </div>

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
@@ -1,5 +1,5 @@
-import {Component, ElementRef, EventEmitter, inject, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
-import {Book, ReadStatus} from '../../../model/book.model';
+import {Component, ElementRef, EventEmitter, inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild} from '@angular/core';
+import {Book, ReadStatus, AdditionalFile} from '../../../model/book.model';
 import {Button} from 'primeng/button';
 import {MenuModule} from 'primeng/menu';
 import {ConfirmationService, MenuItem, MessageService} from 'primeng/api';
@@ -32,7 +32,7 @@ import {ResetProgressTypes} from '../../../../shared/constants/reset-progress-ty
   imports: [Button, MenuModule, CheckboxModule, FormsModule, NgClass, TieredMenu, ProgressBar],
   standalone: true
 })
-export class BookCardComponent implements OnInit, OnDestroy {
+export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
   @Output() checkboxClick = new EventEmitter<{ index: number; bookId: number; selected: boolean; shiftKey: boolean }>();
 
@@ -50,6 +50,8 @@ export class BookCardComponent implements OnInit, OnDestroy {
   items: MenuItem[] | undefined;
   isHovered: boolean = false;
   isImageLoaded: boolean = false;
+  isSubMenuLoading = false;
+  private additionalFilesLoaded = false;
 
   private bookService = inject(BookService);
   private dialogService = inject(DialogService);
@@ -75,6 +77,14 @@ export class BookCardComponent implements OnInit, OnDestroy {
         this.metadataCenterViewMode = user?.userSettings.metadataCenterViewMode ?? 'route';
         this.initMenu();
       });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['book'] && !changes['book'].firstChange) {
+      // Reset the flag when book changes
+      this.additionalFilesLoaded = false;
+      this.initMenu();
+    }
   }
 
   get progressPercentage(): number | null {
@@ -103,6 +113,38 @@ export class BookCardComponent implements OnInit, OnDestroy {
 
   readBook(book: Book): void {
     this.bookService.readBook(book.id);
+  }
+
+  onMenuToggle(event: Event, menu: TieredMenu): void {
+    menu.toggle(event);
+
+    // Load additional files if not already loaded and needed
+    if (!this.additionalFilesLoaded && !this.isSubMenuLoading && this.needsAdditionalFilesData()) {
+      this.isSubMenuLoading = true;
+      this.bookService.getBookByIdFromAPI(this.book.id, true).subscribe({
+        next: (book) => {
+          this.book = book;
+          this.additionalFilesLoaded = true;
+          this.isSubMenuLoading = false;
+          this.initMenu();
+        },
+        error: () => {
+          this.isSubMenuLoading = false;
+        }
+      });
+    }
+  }
+
+  private needsAdditionalFilesData(): boolean {
+    // Don't need to load if already loaded
+    if (this.additionalFilesLoaded) {
+      return false;
+    }
+
+    const hasNoAlternativeFormats = !this.book.alternativeFormats || this.book.alternativeFormats.length === 0;
+    const hasNoSupplementaryFiles = !this.book.supplementaryFiles || this.book.supplementaryFiles.length === 0;
+    return (this.hasDownloadPermission() || this.hasDeleteBookPermission()) &&
+           hasNoAlternativeFormats && hasNoSupplementaryFiles;
   }
 
   private initMenu() {
@@ -142,33 +184,73 @@ export class BookCardComponent implements OnInit, OnDestroy {
     const items: MenuItem[] = [];
 
     if (this.hasDownloadPermission()) {
-      items.push({
-        label: 'Download',
-        icon: 'pi pi-download',
-        command: () => {
-          this.bookService.downloadFile(this.book.id);
-        },
-      });
+      const hasAdditionalFiles = (this.book.alternativeFormats && this.book.alternativeFormats.length > 0) ||
+                                 (this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0);
+
+      if (hasAdditionalFiles) {
+        const downloadItems = this.getDownloadMenuItems();
+        items.push({
+          label: 'Download',
+          icon: 'pi pi-download',
+          items: downloadItems
+        });
+      } else if (this.additionalFilesLoaded) {
+        // Data has been loaded but no additional files exist
+        items.push({
+          label: 'Download',
+          icon: 'pi pi-download',
+          command: () => {
+            this.bookService.downloadFile(this.book.id);
+          }
+        });
+      } else {
+        // Data not loaded yet
+        items.push({
+          label: 'Download',
+          icon: this.isSubMenuLoading ? 'pi pi-spin pi-spinner' : 'pi pi-download',
+          items: [{label: 'Loading...', disabled: true}]
+        });
+      }
     }
 
     if (this.hasDeleteBookPermission()) {
-      items.push({
-        label: 'Delete Book',
-        icon: 'pi pi-trash',
-        command: () => {
-          this.confirmationService.confirm({
-            message: `Are you sure you want to delete "${this.book.metadata?.title}"?`,
-            header: 'Confirm Deletion',
-            icon: 'pi pi-exclamation-triangle',
-            acceptIcon: 'pi pi-trash',
-            rejectIcon: 'pi pi-times',
-            acceptButtonStyleClass: 'p-button-danger',
-            accept: () => {
-              this.bookService.deleteBooks(new Set([this.book.id])).subscribe();
-            }
-          });
-        },
-      });
+      const hasAdditionalFiles = (this.book.alternativeFormats && this.book.alternativeFormats.length > 0) ||
+                                 (this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0);
+
+      if (hasAdditionalFiles) {
+        const deleteItems = this.getDeleteMenuItems();
+        items.push({
+          label: 'Delete',
+          icon: 'pi pi-trash',
+          items: deleteItems
+        });
+      } else if (this.additionalFilesLoaded) {
+        // Data has been loaded but no additional files exist - show delete book option
+        items.push({
+          label: 'Delete',
+          icon: 'pi pi-trash',
+          command: () => {
+            this.confirmationService.confirm({
+              message: `Are you sure you want to delete "${this.book.metadata?.title}"?`,
+              header: 'Confirm Deletion',
+              icon: 'pi pi-exclamation-triangle',
+              acceptIcon: 'pi pi-trash',
+              rejectIcon: 'pi pi-times',
+              acceptButtonStyleClass: 'p-button-danger',
+              accept: () => {
+                this.bookService.deleteBooks(new Set([this.book.id])).subscribe();
+              }
+            });
+          }
+        });
+      } else {
+        // Data not loaded yet
+        items.push({
+          label: 'Delete',
+          icon: this.isSubMenuLoading ? 'pi pi-spin pi-spinner' : 'pi pi-trash',
+          items: [{label: 'Loading...', disabled: true}]
+        });
+      }
     }
 
     if (this.hasEmailBookPermission()) {
@@ -392,6 +474,184 @@ export class BookCardComponent implements OnInit, OnDestroy {
         showHeader: false
       });
     }
+  }
+
+  private getDownloadMenuItems(): MenuItem[] {
+    const items: MenuItem[] = [];
+
+    // Add main book file first
+    items.push({
+      label: `${this.book.fileName || 'Book File'}`,
+      icon: 'pi pi-file',
+      command: () => {
+        this.bookService.downloadFile(this.book.id);
+      }
+    });
+
+    // Add separator if there are additional files
+    if (this.hasAdditionalFiles()) {
+      items.push({ separator: true });
+    }
+
+    // Add alternative formats
+    if (this.book.alternativeFormats && this.book.alternativeFormats.length > 0) {
+      this.book.alternativeFormats.forEach(format => {
+        const extension = this.getFileExtension(format.filePath);
+        items.push({
+          label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
+          icon: this.getFileIcon(extension),
+          command: () => this.downloadAdditionalFile(this.book.id, format.id)
+        });
+      });
+    }
+
+    // Add separator if both alternative formats and supplementary files exist
+    if (this.book.alternativeFormats && this.book.alternativeFormats.length > 0 &&
+        this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0) {
+      items.push({ separator: true });
+    }
+
+    // Add supplementary files
+    if (this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0) {
+      this.book.supplementaryFiles.forEach(file => {
+        const extension = this.getFileExtension(file.filePath);
+        items.push({
+          label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
+          icon: this.getFileIcon(extension),
+          command: () => this.downloadAdditionalFile(this.book.id, file.id)
+        });
+      });
+    }
+
+    return items;
+  }
+
+  private getDeleteMenuItems(): MenuItem[] {
+    const items: MenuItem[] = [];
+
+    // Add main book deletion
+    items.push({
+      label: 'Book',
+      icon: 'pi pi-book',
+      command: () => {
+        this.confirmationService.confirm({
+          message: `Are you sure you want to delete "${this.book.metadata?.title}"?`,
+          header: 'Confirm Deletion',
+          icon: 'pi pi-exclamation-triangle',
+          acceptIcon: 'pi pi-trash',
+          rejectIcon: 'pi pi-times',
+          acceptButtonStyleClass: 'p-button-danger',
+          accept: () => {
+            this.bookService.deleteBooks(new Set([this.book.id])).subscribe();
+          }
+        });
+      }
+    });
+
+    // Add separator if there are additional files
+    if (this.hasAdditionalFiles()) {
+      items.push({ separator: true });
+    }
+
+    // Add alternative formats
+    if (this.book.alternativeFormats && this.book.alternativeFormats.length > 0) {
+      this.book.alternativeFormats.forEach(format => {
+        const extension = this.getFileExtension(format.filePath);
+        items.push({
+          label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
+          icon: this.getFileIcon(extension),
+          command: () => this.deleteAdditionalFile(this.book.id, format.id, format.fileName || 'file')
+        });
+      });
+    }
+
+    // Add separator if both alternative formats and supplementary files exist
+    if (this.book.alternativeFormats && this.book.alternativeFormats.length > 0 &&
+        this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0) {
+      items.push({ separator: true });
+    }
+
+    // Add supplementary files
+    if (this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0) {
+      this.book.supplementaryFiles.forEach(file => {
+        const extension = this.getFileExtension(file.filePath);
+        items.push({
+          label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
+          icon: this.getFileIcon(extension),
+          command: () => this.deleteAdditionalFile(this.book.id, file.id, file.fileName || 'file')
+        });
+      });
+    }
+
+    return items;
+  }
+
+  private hasAdditionalFiles(): boolean {
+    return !!(this.book.alternativeFormats && this.book.alternativeFormats.length > 0) ||
+           !!(this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0);
+  }
+
+  private downloadAdditionalFile(bookId: number, fileId: number): void {
+    this.bookService.downloadAdditionalFile(bookId, fileId);
+  }
+
+  private deleteAdditionalFile(bookId: number, fileId: number, fileName: string): void {
+    this.confirmationService.confirm({
+      message: `Are you sure you want to delete the additional file "${fileName}"?`,
+      header: 'Confirm File Deletion',
+      icon: 'pi pi-exclamation-triangle',
+      acceptIcon: 'pi pi-trash',
+      rejectIcon: 'pi pi-times',
+      acceptButtonStyleClass: 'p-button-danger',
+      accept: () => {
+        this.bookService.deleteAdditionalFile(bookId, fileId).subscribe({
+          next: () => {
+            this.messageService.add({
+              severity: 'success',
+              summary: 'Success',
+              detail: `Additional file "${fileName}" deleted successfully`
+            });
+          },
+          error: (error) => {
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: `Failed to delete additional file: ${error.message || 'Unknown error'}`
+            });
+          }
+        });
+      }
+    });
+  }
+
+  private getFileExtension(filePath?: string): string | null {
+    if (!filePath) return null;
+    const parts = filePath.split('.');
+    if (parts.length < 2) return null;
+    return parts.pop()?.toUpperCase() || null;
+  }
+
+  private getFileIcon(fileType: string | null): string {
+    if (!fileType) return 'pi pi-file';
+    switch (fileType.toLowerCase()) {
+      case 'pdf':
+        return 'pi pi-file-pdf';
+      case 'epub':
+      case 'mobi':
+      case 'azw3':
+        return 'pi pi-book';
+      case 'cbz':
+      case 'cbr':
+      case 'cbx':
+        return 'pi pi-image';
+      default:
+        return 'pi pi-file';
+    }
+  }
+
+  private getFileSizeInMB(fileInfo: AdditionalFile): string {
+    const sizeKb = fileInfo?.fileSizeKb;
+    return sizeKb != null ? `${(sizeKb / 1024).toFixed(2)} MB` : '-';
   }
 
   private isAdmin(): boolean {

--- a/booklore-ui/src/app/book/model/book.model.ts
+++ b/booklore-ui/src/app/book/model/book.model.ts
@@ -3,6 +3,23 @@ import {NewPdfReaderSetting} from '../../settings/user-management/user.service';
 
 export type BookType = "PDF" | "EPUB" | "CBX";
 
+export enum AdditionalFileType {
+  ALTERNATIVE_FORMAT = 'ALTERNATIVE_FORMAT',
+  SUPPLEMENTARY = 'SUPPLEMENTARY'
+}
+
+export interface AdditionalFile {
+  id: number;
+  bookId: number;
+  fileName: string;
+  filePath: string;
+  fileSubPath?: string;
+  additionalFileType: AdditionalFileType;
+  fileSizeKb?: number;
+  description?: string;
+  addedOn?: string;
+}
+
 export interface Book {
   id: number;
   bookType: BookType;
@@ -24,6 +41,8 @@ export interface Book {
   readStatus?: ReadStatus;
   dateFinished?: string;
   libraryPath?: { id: number };
+  alternativeFormats?: AdditionalFile[];
+  supplementaryFiles?: AdditionalFile[];
 }
 
 export interface EpubProgress {

--- a/booklore-ui/src/app/book/model/book.model.ts
+++ b/booklore-ui/src/app/book/model/book.model.ts
@@ -8,19 +8,22 @@ export enum AdditionalFileType {
   SUPPLEMENTARY = 'SUPPLEMENTARY'
 }
 
-export interface AdditionalFile {
+export interface FileInfo {
+  fileName?: string;
+  filePath?: string;
+  fileSubPath?: string;
+  fileSizeKb?: number;
+}
+
+export interface AdditionalFile extends FileInfo {
   id: number;
   bookId: number;
-  fileName: string;
-  filePath: string;
-  fileSubPath?: string;
   additionalFileType: AdditionalFileType;
-  fileSizeKb?: number;
   description?: string;
   addedOn?: string;
 }
 
-export interface Book {
+export interface Book extends FileInfo {
   id: number;
   bookType: BookType;
   libraryId: number;
@@ -32,10 +35,6 @@ export interface Book {
   pdfProgress?: PdfProgress;
   cbxProgress?: CbxProgress;
   koreaderProgress?: KoReaderProgress;
-  filePath?: string;
-  fileSubPath?: string;
-  fileName?: string;
-  fileSizeKb?: number;
   seriesCount?: number | null;
   metadataMatchScore?: number | null;
   readStatus?: ReadStatus;

--- a/booklore-ui/src/app/book/service/book.service.ts
+++ b/booklore-ui/src/app/book/service/book.service.ts
@@ -51,6 +51,26 @@ export class BookService {
     ).subscribe();
   }
 
+  refreshBooks(): void {
+    this.http.get<Book[]>(this.url).pipe(
+      tap(books => {
+        this.bookStateSubject.next({
+          books: books || [],
+          loaded: true,
+          error: null,
+        });
+      }),
+      catchError(error => {
+        this.bookStateSubject.next({
+          books: null,
+          loaded: true,
+          error: error.message,
+        });
+        return of(null);
+      })
+    ).subscribe();
+  }
+
   getBookByIdFromState(bookId: number): Book | undefined {
     const currentState = this.bookStateSubject.value;
     return currentState.books?.find(book => +book.id === +bookId);
@@ -217,6 +237,44 @@ export class BookService {
           severity: 'error',
           summary: 'Delete Failed',
           detail: error?.error?.message || error?.message || 'An error occurred while deleting books.',
+        });
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteAdditionalFile(bookId: number, fileId: number): Observable<void> {
+    const deleteUrl = `${this.url}/${bookId}/files/${fileId}`;
+    return this.http.delete<void>(deleteUrl).pipe(
+      tap(() => {
+        const currentState = this.bookStateSubject.value;
+        const updatedBooks = (currentState.books || []).map(book => {
+          if (book.id === bookId) {
+            return {
+              ...book,
+              alternativeFormats: book.alternativeFormats?.filter(file => file.id !== fileId),
+              supplementaryFiles: book.supplementaryFiles?.filter(file => file.id !== fileId)
+            };
+          }
+          return book;
+        });
+
+        this.bookStateSubject.next({
+          ...currentState,
+          books: updatedBooks
+        });
+
+        this.messageService.add({
+          severity: 'success',
+          summary: 'File Deleted',
+          detail: 'Additional file deleted successfully.'
+        });
+      }),
+      catchError(error => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Delete Failed',
+          detail: error?.error?.message || error?.message || 'An error occurred while deleting the file.'
         });
         return throwError(() => error);
       })

--- a/booklore-ui/src/app/book/service/book.service.ts
+++ b/booklore-ui/src/app/book/service/book.service.ts
@@ -2,7 +2,7 @@ import {inject, Injectable} from '@angular/core';
 import {BehaviorSubject, first, Observable, of, throwError} from 'rxjs';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {catchError, filter, map, tap} from 'rxjs/operators';
-import {Book, BookDeletionResponse, BookMetadata, BookRecommendation, BookSetting, BulkMetadataUpdateRequest, MetadataUpdateWrapper, ReadStatus} from '../model/book.model';
+import {Book, BookDeletionResponse, BookMetadata, BookRecommendation, BookSetting, BulkMetadataUpdateRequest, MetadataUpdateWrapper, ReadStatus, AdditionalFileType, AdditionalFile} from '../model/book.model';
 import {BookState} from '../model/state/book-state.model';
 import {API_CONFIG} from '../../config/api-config';
 import {FetchMetadataRequest} from '../../metadata/model/request/fetch-metadata-request.model';
@@ -275,6 +275,52 @@ export class BookService {
           severity: 'error',
           summary: 'Delete Failed',
           detail: error?.error?.message || error?.message || 'An error occurred while deleting the file.'
+        });
+        return throwError(() => error);
+      })
+    );
+  }
+
+  uploadAdditionalFile(bookId: number, file: File, fileType: AdditionalFileType, description?: string): Observable<AdditionalFile> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('additionalFileType', fileType);
+    if (description) {
+      formData.append('description', description);
+    }
+
+    return this.http.post<AdditionalFile>(`${this.url}/${bookId}/files`, formData).pipe(
+      tap((newFile) => {
+        const currentState = this.bookStateSubject.value;
+        const updatedBooks = (currentState.books || []).map(book => {
+          if (book.id === bookId) {
+            const updatedBook = { ...book };
+            if (fileType === AdditionalFileType.ALTERNATIVE_FORMAT) {
+              updatedBook.alternativeFormats = [...(book.alternativeFormats || []), newFile];
+            } else {
+              updatedBook.supplementaryFiles = [...(book.supplementaryFiles || []), newFile];
+            }
+            return updatedBook;
+          }
+          return book;
+        });
+
+        this.bookStateSubject.next({
+          ...currentState,
+          books: updatedBooks
+        });
+
+        this.messageService.add({
+          severity: 'success',
+          summary: 'File Uploaded',
+          detail: 'Additional file uploaded successfully.'
+        });
+      }),
+      catchError(error => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Upload Failed',
+          detail: error?.error?.message || error?.message || 'An error occurred while uploading the file.'
         });
         return throwError(() => error);
       })

--- a/booklore-ui/src/app/book/service/book.service.ts
+++ b/booklore-ui/src/app/book/service/book.service.ts
@@ -238,6 +238,21 @@ export class BookService {
       });
   }
 
+  downloadAdditionalFile(bookId: number, fileId: number): void {
+    const downloadUrl = `${this.url}/${bookId}/files/${fileId}/download`;
+    this.http.get(downloadUrl, {responseType: 'blob', observe: 'response'})
+      .subscribe({
+        next: (response) => {
+          const contentDisposition = response.headers.get('Content-Disposition');
+          const filename = contentDisposition
+            ? contentDisposition.match(/filename="(.+?)"/)?.[1] || `additional_file_${fileId}`
+            : `additional_file_${fileId}`;
+          this.saveFile(response.body as Blob, filename);
+        },
+        error: (err) => console.error('Error downloading additional file:', err),
+      });
+  }
+
   private saveFile(blob: Blob, filename: string): void {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
@@ -377,7 +377,7 @@
               (onClick)="assignShelf(book.id)">
             </p-button>
             @if (userData.permissions.canDownload || userData.permissions.admin) {
-              @if (book.alternativeFormats && book.alternativeFormats.length > 0) {
+              @if ((book.alternativeFormats && book.alternativeFormats.length > 0) || (book.supplementaryFiles && book.supplementaryFiles.length > 0)) {
                 @if (downloadMenuItems$ | async; as downloadItems) {
                   <p-splitbutton
                     label="Download"

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
@@ -377,13 +377,25 @@
               (onClick)="assignShelf(book.id)">
             </p-button>
             @if (userData.permissions.canDownload || userData.permissions.admin) {
-              <p-button
-                label="Download"
-                icon="pi pi-download"
-                severity="success"
-                outlined
-                (onClick)="download(book.id)">
-              </p-button>
+              @if (book.alternativeFormats && book.alternativeFormats.length > 0) {
+                @if (downloadMenuItems$ | async; as downloadItems) {
+                  <p-splitbutton
+                    label="Download"
+                    icon="pi pi-download"
+                    [model]="downloadItems"
+                    (onClick)="download(book.id)"
+                    severity="success"
+                    outlined/>
+                }
+              } @else {
+                <p-button
+                  label="Download"
+                  icon="pi pi-download"
+                  severity="success"
+                  outlined
+                  (onClick)="download(book.id)">
+                </p-button>
+              }
             }
             @if (userData.permissions.canEmailBook || userData.permissions.admin) {
               @if (emailMenuItems$ | async; as emailItems) {

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.html
@@ -427,7 +427,7 @@
             @if (userData.permissions.canDeleteBook || userData.permissions.admin) {
               @if (otherItems$ | async; as otherItems) {
                 <p-button icon="pi pi-ellipsis-v" outlined severity="danger" (click)="entitymenu.toggle($event)"></p-button>
-                <p-menu #entitymenu [model]="otherItems" [popup]="true" appendTo="body"></p-menu>
+                <p-tieredMenu #entitymenu [model]="otherItems" [popup]="true" appendTo="body"></p-tieredMenu>
               }
             }
           </div>

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
@@ -30,6 +30,7 @@ import {InfiniteScrollDirective} from 'ngx-infinite-scroll';
 import {BookCardLiteComponent} from '../../../book/components/book-card-lite/book-card-lite-component';
 import {ResetProgressType, ResetProgressTypes} from '../../../shared/constants/reset-progress-type';
 import {TieredMenu} from 'primeng/tieredmenu';
+import {AdditionalFileUploaderComponent} from '../../../book/components/additional-file-uploader/additional-file-uploader.component';
 
 @Component({
   selector: 'app-metadata-viewer',
@@ -152,6 +153,22 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
       filter((book): book is Book => book !== null),
       map((book): MenuItem[] => {
         const items: MenuItem[] = [
+          {
+            label: 'Upload File',
+            icon: 'pi pi-upload',
+            command: () => {
+              this.dialogService.open(AdditionalFileUploaderComponent, {
+                header: 'Upload Additional File',
+                modal: true,
+                closable: true,
+                style: {
+                  position: 'absolute',
+                  top: '10%',
+                },
+                data: {book}
+              });
+            },
+          },
           {
             label: 'Delete Book',
             icon: 'pi pi-trash',

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
@@ -222,15 +222,39 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
         ];
 
         // Add delete additional files menu if there are any additional files
-        if (book.alternativeFormats && book.alternativeFormats.length > 0) {
-          const deleteFileItems: MenuItem[] = book.alternativeFormats.map(format => {
-            const extension = this.getFileExtension(format.filePath);
-            return {
-              label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
-              icon: this.getFileIcon(extension),
-              command: () => this.deleteAdditionalFile(book.id, format.id, format.fileName || 'file')
-            } as MenuItem;
-          });
+        if ((book.alternativeFormats && book.alternativeFormats.length > 0) ||
+            (book.supplementaryFiles && book.supplementaryFiles.length > 0)) {
+          const deleteFileItems: MenuItem[] = [];
+
+          // Add alternative formats
+          if (book.alternativeFormats && book.alternativeFormats.length > 0) {
+            book.alternativeFormats.forEach(format => {
+              const extension = this.getFileExtension(format.filePath);
+              deleteFileItems.push({
+                label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
+                icon: this.getFileIcon(extension),
+                command: () => this.deleteAdditionalFile(book.id, format.id, format.fileName || 'file')
+              });
+            });
+          }
+
+          // Add separator if both types exist
+          if (book.alternativeFormats && book.alternativeFormats.length > 0 &&
+              book.supplementaryFiles && book.supplementaryFiles.length > 0) {
+            deleteFileItems.push({ separator: true });
+          }
+
+          // Add supplementary files
+          if (book.supplementaryFiles && book.supplementaryFiles.length > 0) {
+            book.supplementaryFiles.forEach(file => {
+              const extension = this.getFileExtension(file.filePath);
+              deleteFileItems.push({
+                label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
+                icon: this.getFileIcon(extension),
+                command: () => this.deleteAdditionalFile(book.id, file.id, file.fileName || 'file')
+              });
+            });
+          }
 
           items.push({
             label: 'Delete Additional Files',

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
@@ -6,7 +6,7 @@ import {BookService} from '../../../book/service/book.service';
 import {Rating, RatingRateEvent} from 'primeng/rating';
 import {FormsModule} from '@angular/forms';
 import {Tag} from 'primeng/tag';
-import {Book, BookMetadata, BookRecommendation, ReadStatus} from '../../../book/model/book.model';
+import {Book, BookMetadata, BookRecommendation, ReadStatus, FileInfo} from '../../../book/model/book.model';
 import {Divider} from 'primeng/divider';
 import {UrlHelperService} from '../../../utilities/service/url-helper.service';
 import {UserService} from '../../../settings/user-management/user.service';
@@ -58,7 +58,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
   readMenuItems$!: Observable<MenuItem[]>;
   refreshMenuItems$!: Observable<MenuItem[]>;
   otherItems$!: Observable<MenuItem[]>;
-
+  downloadMenuItems$!: Observable<MenuItem[]>;
   bookInSeries: Book[] = [];
   isExpanded = false;
   showFilePath = false;
@@ -127,6 +127,24 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
           command: () => this.read(book.id, 'streaming')
         }
       ])
+    );
+
+    this.downloadMenuItems$ = this.book$.pipe(
+      filter((book): book is Book => book !== null && book.alternativeFormats !== undefined && book.alternativeFormats.length > 0),
+      map((book): MenuItem[] => {
+        const items: MenuItem[] = [];
+        if (book.alternativeFormats && book.alternativeFormats.length > 0) {
+          book.alternativeFormats.forEach(format => {
+            const extension = this.getFileExtension(format.filePath);
+            items.push({
+              label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
+              icon: this.getFileIcon(extension),
+              command: () => this.downloadAdditionalFile(book.id, format.id)
+            });
+          });
+        }
+        return items;
+      })
     );
 
     this.otherItems$ = this.book$.pipe(
@@ -228,6 +246,10 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
 
   download(bookId: number) {
     this.bookService.downloadFile(bookId);
+  }
+
+  downloadAdditionalFile(bookId: number, fileId: number) {
+    this.bookService.downloadAdditionalFile(bookId, fileId);
   }
 
   quickRefresh(bookId: number) {
@@ -426,8 +448,8 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     return lockedKeys.length > 0 && lockedKeys.every(k => metadata[k] === true);
   }
 
-  getFileSizeInMB(book: Book | null): string {
-    const sizeKb = book?.fileSizeKb;
+  getFileSizeInMB(fileInfo: FileInfo | null | undefined): string {
+    const sizeKb = fileInfo?.fileSizeKb;
     return sizeKb != null ? `${(sizeKb / 1024).toFixed(2)} MB` : '-';
   }
 
@@ -456,6 +478,24 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     const parts = filePath.split('.');
     if (parts.length < 2) return null;
     return parts.pop()?.toUpperCase() || null;
+  }
+
+  getFileIcon(fileType: string | null): string {
+    if (!fileType) return 'pi pi-file';
+    switch (fileType.toLowerCase()) {
+      case 'pdf':
+        return 'pi pi-file-pdf';
+      case 'epub':
+      case 'mobi':
+      case 'azw3':
+        return 'pi pi-book';
+      case 'cbz':
+      case 'cbr':
+      case 'cbx':
+        return 'pi pi-image';
+      default:
+        return 'pi pi-file';
+    }
   }
 
   getFileTypeColorClass(fileType: string | null | undefined): string {

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
@@ -132,9 +132,13 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     );
 
     this.downloadMenuItems$ = this.book$.pipe(
-      filter((book): book is Book => book !== null && book.alternativeFormats !== undefined && book.alternativeFormats.length > 0),
+      filter((book): book is Book => book !== null &&
+        ((book.alternativeFormats !== undefined && book.alternativeFormats.length > 0) ||
+         (book.supplementaryFiles !== undefined && book.supplementaryFiles.length > 0))),
       map((book): MenuItem[] => {
         const items: MenuItem[] = [];
+
+        // Add alternative formats
         if (book.alternativeFormats && book.alternativeFormats.length > 0) {
           book.alternativeFormats.forEach(format => {
             const extension = this.getFileExtension(format.filePath);
@@ -145,6 +149,25 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
             });
           });
         }
+
+        // Add separator if both types exist
+        if (book.alternativeFormats && book.alternativeFormats.length > 0 &&
+            book.supplementaryFiles && book.supplementaryFiles.length > 0) {
+          items.push({ separator: true });
+        }
+
+        // Add supplementary files
+        if (book.supplementaryFiles && book.supplementaryFiles.length > 0) {
+          book.supplementaryFiles.forEach(file => {
+            const extension = this.getFileExtension(file.filePath);
+            items.push({
+              label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
+              icon: this.getFileIcon(extension),
+              command: () => this.downloadAdditionalFile(book.id, file.id)
+            });
+          });
+        }
+
         return items;
       })
     );


### PR DESCRIPTION
## Additional Files Support (2 of 3 PRs)

This pull request introduces support for managing additional files in the UI, including the following changes.

This is a continuation of the work for #221 and serves as the second step, focusing on the UI for this feature.

> [!WARNING]
>
> I do not have the necessary permissions to push new branches to this repository. As a result, I cannot set the base branch to `feature/book-file-formats`. Consequently, this PR includes changes from #868 because the base branch is set to `develop`.

### Upload Additional Files to an Existing Book:

<img width="381" height="261" alt="image" src="https://github.com/user-attachments/assets/5ef65f1c-749b-4419-99e9-8504f35282e0" />

<img width="1033" height="892" alt="image" src="https://github.com/user-attachments/assets/5965c57a-69b6-4ee6-86d9-f166ca268c1b" />

### Download Additional Formats and Supplementary Files:

<img width="912" height="262" alt="image" src="https://github.com/user-attachments/assets/330ad275-ad8a-41c4-b30c-af3762370f54" />

### Delete Additional Formats and Supplementary Files:

<img width="1213" height="358" alt="image" src="https://github.com/user-attachments/assets/3e8b1fd8-d0b8-4152-aaae-ef7b639ded7a" />

### Library View extended menu:

<img width="1347" height="486" alt="image" src="https://github.com/user-attachments/assets/553be8dc-d436-463b-abff-329bf23c367d" />
<img width="1178" height="484" alt="image" src="https://github.com/user-attachments/assets/8d0be730-f0f2-4fab-878d-3221e29dff4b" />
