### PR TITLE
feat: move the series count overlay & add title tooltip

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
@@ -66,7 +66,7 @@
 
   <div [hidden]="bottomBarHidden">
     <div class="book-title-container flex items-center">
-      <h4 class="book-title m-0 pl-2">{{ book.metadata?.title }}</h4>
+      <h4 class="book-title m-0 pl-2" [title]="book.metadata?.title">{{ book.metadata?.title }}</h4>
       <p-tieredmenu #menu [model]="items" [popup]="true" appendTo="body"></p-tieredmenu>
       <p-button
         class="custom-button-padding"

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.scss
@@ -157,7 +157,7 @@
 .series-count-overlay {
   position: absolute;
   top: 4px;
-  right: 4px;
+  left: 4px;
   background-color: var(--primary-color);
   color: var(--primary-text-color-dark);
   font-size: 0.75rem;

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.scss
@@ -112,6 +112,9 @@
   transition: opacity 0.2s ease, visibility 0.2s ease;
   z-index: 2;
 }
+.select-checkbox .p-checkbox {
+  vertical-align: top;
+}
 
 .cover-container:hover .select-checkbox,
 .book-card.selected .select-checkbox {
@@ -144,8 +147,8 @@
 
 .series-number-overlay {
   position: absolute;
-  top: 4px;
-  left: 4px;
+  bottom: 8px;
+  left: 8px;
   background-color: rgba(0, 0, 0, 0.7);
   color: white;
   font-size: 0.75rem;
@@ -156,8 +159,8 @@
 
 .series-count-overlay {
   position: absolute;
-  top: 4px;
-  left: 4px;
+  top: 8px;
+  left: 8px;
   background-color: var(--primary-color);
   color: var(--primary-text-color-dark);
   font-size: 0.75rem;
@@ -169,6 +172,10 @@
   font-weight: 600;
   text-align: center;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
+}
+
+.series-number-overlay + .series-count-overlay {
+  top: calc(8px + 1.5rem)
 }
 
 ::ng-deep .progress-incomplete .p-progressbar-value {


### PR DESCRIPTION
Currently the checkbox is hard to hit if the series count is visible. Further more, the title is cut so it's impossible to tell what is what. 

This PR will:

- move the series count overlay to the left side of the card
- align the count overlay to the checkbox
- move the series number to bottom
- add the title as a tooltip.

<img width="327" height="500" alt="image" src="https://github.com/user-attachments/assets/1f8dd602-1f04-4656-8f3b-2c541e430136" />

<img width="341" height="531" alt="image" src="https://github.com/user-attachments/assets/4a6ee856-1691-4344-8fd1-53db439e05bd" />

