### PR TITLE
Update docker-compose.yml example file to the new booklore Docker Hub image identifier

### DIFF
--- a/example-docker/docker-compose.yml
+++ b/example-docker/docker-compose.yml
@@ -1,7 +1,7 @@
 name: booklore
 services:
   booklore:
-    image: ghcr.io/adityachandelgit/booklore-app:${BOOKLORE_IMAGE_TAG}
+    image: booklore/booklore:${BOOKLORE_IMAGE_TAG}
     container_name: booklore_server
     env_file:
       - .env


### PR DESCRIPTION
The Docker image was moved to a new repository on Docker Hub, so this must be reflected in the docker-compose.yml example file