### PR TITLE
feat: Add docker compose to quickly run a dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,9 @@ cd booklore
 
 ## 🧱 Local Development Setup
 
+Either run  `docker compose -f dev.docker-compose.yml up` or install & run everything Locally (described below).
+
+
 ### 1. Prerequisites
 
 - **Java 21+**

--- a/booklore-ui/package.json
+++ b/booklore-ui/package.json
@@ -25,8 +25,6 @@
     "@stomp/rx-stomp": "^2.0.1",
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/postcss": "^4.1.8",
-    "@tweenjs/tween.js": "^25.0.0",
-    "@types/three": "^0.179.0",
     "angular-oauth2-oidc": "^20.0.0",
     "epubjs": "^0.3.93",
     "jwt-decode": "^4.0.0",

--- a/booklore-ui/package.json
+++ b/booklore-ui/package.json
@@ -25,6 +25,8 @@
     "@stomp/rx-stomp": "^2.0.1",
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/postcss": "^4.1.8",
+    "@tweenjs/tween.js": "^25.0.0",
+    "@types/three": "^0.179.0",
     "angular-oauth2-oidc": "^20.0.0",
     "epubjs": "^0.3.93",
     "jwt-decode": "^4.0.0",
@@ -58,7 +60,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
     "tailwindcss": "3.4.17",
-    "typescript": "^5.8.2",
+    "typescript": "~5.8.2",
     "typescript-eslint": "^8.39.0"
   }
 }

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  backend:
+    image: gradle:8-jdk21-alpine
+    command: sh -c "cd /booklore-api && ./gradlew bootRun"
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+    environment:
+      - DATABASE_URL=jdbc:mariadb://backend_db:3306/booklore
+      - DATABASE_USERNAME=booklore
+      - DATABASE_PASSWORD=booklore
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    depends_on:
+      - backend_db
+    volumes:
+      - './booklore-api:/booklore-api'
+      - ./shared/data:/app/data
+      - ./shared/books:/books
+
+  backend_db:
+    image: mariadb:11.4
+    container_name: backend_db
+    volumes:
+      - backend_db:/var/lib/mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=booklore
+      - MYSQL_DATABASE=booklore
+      - MYSQL_USER=booklore
+      - MYSQL_PASSWORD=booklore
+    healthcheck:
+      test: [ "CMD", "mariadb-admin", "ping", "-h", "localhost", "-uroot", "-pbooklore" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  ui:
+    image: node:22-alpine
+    command: sh -c "cd /angular-app && npm install -g @angular/cli --force && npm install --force && ng serve --host 0.0.0.0"
+    environment:
+      - NODE_ENV=development
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    volumes:
+      - './booklore-ui:/angular-app'
+
+        # you can have node_modules in a volume. however, if you enable this, expect trouble in some IDEs, as the deps are not available anymore
+        # - node_modules:/angular-app/node_modules
+
+        # we ignore package-lock otherwise will throw
+        # An unhandled exception occurred: Cannot find module @rollup/rollup-linux-x64-musl. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).
+        # Please try `npm i` again after removing both package-lock.json and node_modules directory.
+      - '/dev/null:/angular-app/package-lock.json'
+    ports:
+      - "${FRONTEND_PORT:-4200}:4200"
+
+volumes:
+  node_modules:
+  backend_db:


### PR DESCRIPTION
No need to install java, node and all stuff locally, just run `docker compose -f dev.docker-compose.yml up` and you're good to go.

You can customize exposed ports by adding an `.env` file with `BACKEND_PORT` & `FRONTEND_PORT` value set (defaults are 8080 & 4200).
