### PR TITLE
Feat: automatically set library/path if there is only one option available

### DIFF
--- a/booklore-ui/src/app/bookdrop/bookdrop-file-review-component/bookdrop-file-review.component.ts
+++ b/booklore-ui/src/app/bookdrop/bookdrop-file-review-component/bookdrop-file-review.component.ts
@@ -203,7 +203,7 @@ export class BookdropFileReviewComponent implements OnInit {
   onLibraryChange(file: BookdropFileUI): void {
     const lib = this.libraries.find(l => String(l.id) === file.selectedLibraryId);
     file.availablePaths = lib?.paths.map(p => ({id: String(p.id ?? ''), name: p.path})) ?? [];
-    file.selectedPathId = null;
+    file.selectedPathId = file.availablePaths.length === 1 ? file.availablePaths[0].id : null;
   }
 
   onMetadataCopied(fileId: number, copied: boolean): void {

--- a/booklore-ui/src/app/bookdrop/bookdrop-file-review-component/bookdrop-file-review.component.ts
+++ b/booklore-ui/src/app/bookdrop/bookdrop-file-review-component/bookdrop-file-review.component.ts
@@ -75,7 +75,8 @@ export class BookdropFileReviewComponent implements OnInit {
   appSettings$: Observable<AppSettings | null> = this.appSettingsService.appSettings$;
 
   uploadPattern = '';
-  defaultLibraryId: string | null = null;
+  _defaultLibraryId: string | null = null;
+
   defaultPathId: string | null = null;
   libraries: Library[] = [];
   bookdropFileUis: BookdropFileUI[] = [];
@@ -106,6 +107,20 @@ export class BookdropFileReviewComponent implements OnInit {
       .subscribe(settings => {
         this.uploadPattern = settings?.uploadPattern ?? '';
       });
+  }
+
+  get defaultLibraryId() {
+    return this._defaultLibraryId;
+  }
+
+  set defaultLibraryId(value: string | null) {
+    this._defaultLibraryId = value;
+
+    const selected = this.libraries.find((lib) => lib?.id && String(lib.id) === value)
+
+    if (selected && selected.paths.length ===1) {
+      this.defaultPathId = String(selected.paths[0].id)
+    }
   }
 
   get libraryOptions() {

--- a/booklore-ui/src/app/utilities/component/book-uploader/book-uploader.component.ts
+++ b/booklore-ui/src/app/utilities/component/book-uploader/book-uploader.component.ts
@@ -44,8 +44,20 @@ interface UploadingFile {
 export class BookUploaderComponent implements OnInit {
   files: UploadingFile[] = [];
   isUploading: boolean = false;
-  selectedLibrary: Library | null = null;
+  _selectedLibrary: Library | null = null;
   selectedPath: LibraryPath | null = null;
+
+  get selectedLibrary(): Library | null {
+    return this._selectedLibrary;
+  }
+
+  set selectedLibrary(library: Library | null) {
+    this._selectedLibrary = library;
+
+    if(library?.paths?.length === 1) {
+      this.selectedPath = library.paths[0];
+    }
+  }
 
   private readonly libraryService = inject(LibraryService);
   private readonly messageService = inject(MessageService);
@@ -70,6 +82,15 @@ export class BookUploaderComponent implements OnInit {
       .subscribe(settings => {
         this.maxFileSizeBytes = (settings?.maxFileUploadSizeInMb ?? 100) * 1024 * 1024;
       });
+
+    this.libraryState$.subscribe(state => {
+      if (state?.libraries?.length !== 1 || this.selectedLibrary) {
+        return;
+      }
+
+      this.selectedLibrary = state.libraries[0];
+    });
+
   }
 
   hasPendingFiles(): boolean {

--- a/booklore-ui/src/app/utilities/component/book-uploader/book-uploader.component.ts
+++ b/booklore-ui/src/app/utilities/component/book-uploader/book-uploader.component.ts
@@ -47,18 +47,6 @@ export class BookUploaderComponent implements OnInit {
   _selectedLibrary: Library | null = null;
   selectedPath: LibraryPath | null = null;
 
-  get selectedLibrary(): Library | null {
-    return this._selectedLibrary;
-  }
-
-  set selectedLibrary(library: Library | null) {
-    this._selectedLibrary = library;
-
-    if(library?.paths?.length === 1) {
-      this.selectedPath = library.paths[0];
-    }
-  }
-
   private readonly libraryService = inject(LibraryService);
   private readonly messageService = inject(MessageService);
   private readonly appSettingsService = inject(AppSettingsService);
@@ -90,7 +78,18 @@ export class BookUploaderComponent implements OnInit {
 
       this.selectedLibrary = state.libraries[0];
     });
+  }
 
+  get selectedLibrary(): Library | null {
+    return this._selectedLibrary;
+  }
+
+  set selectedLibrary(library: Library | null) {
+    this._selectedLibrary = library;
+
+    if(library?.paths?.length === 1) {
+      this.selectedPath = library.paths[0];
+    }
   }
 
   hasPendingFiles(): boolean {


### PR DESCRIPTION
There are some cases where the UI requires extra steps: whenever you have to pick the library & path, even if you only have one option available. With this patch, I want to change this, so if you only have one option, that will automagically selected.

_(i'm still not sure if the first option should be selected even if there are more than one items, suggestions?)_

There are multiple components that implements this, so it will take a bit to deal with all.

- [x] Book Uploader (library)
- [x] Book Drop manager (bulk)
- [x] Book Drop manager (individual)
- ❓ somewhere else? 