### PR TITLE
feature: add tooltips on book titles

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
@@ -1,4 +1,9 @@
 <div class="book-card"
+     tooltipPosition="bottom"
+     autoHide="false"
+     tooltipStyleClass="text-xs text-center"
+     [pTooltip]="book.metadata?.title"
+
      [class.selected]="isSelected"
      (mouseover)="isHovered = true"
      (mouseout)="isHovered = false">
@@ -31,8 +36,17 @@
       </div>
     }
 
-    <p-button [rounded]="true" icon="pi pi-info" class="info-btn" (click)="openBookInfo(book)"></p-button>
-    <p-button [hidden]="readButtonHidden" [rounded]="true" icon="pi pi-book" class="read-btn" (click)="readBook(book)"></p-button>
+    <p-button
+        tooltipPosition="top"
+        tooltipStyleClass="text-xs text-center"
+        pTooltip="Open Book Info"
+        [rounded]="true" icon="pi pi-info" class="info-btn" (click)="openBookInfo(book)"></p-button>
+
+    <p-button
+        tooltipPosition="top"
+        tooltipStyleClass="text-xs text-center"
+        pTooltip="{{ koProgressPercentage || progressPercentage ? 'Continue Reading' : 'Start Reading' }}"
+        [hidden]="readButtonHidden" [rounded]="true" icon="pi pi-book" class="read-btn" (click)="readBook(book)"></p-button>
 
     @if (isCheckboxEnabled) {
       <p-checkbox
@@ -66,7 +80,7 @@
 
   <div [hidden]="bottomBarHidden">
     <div class="book-title-container flex items-center">
-      <h4 class="book-title m-0 pl-2" [title]="book.metadata?.title">{{ book.metadata?.title }}</h4>
+      <h4 class="book-title m-0 pl-2">{{ book.metadata?.title }}</h4>
       <p-tieredmenu #menu [model]="items" [popup]="true" appendTo="body"></p-tieredmenu>
       <p-button
         class="custom-button-padding"

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
@@ -1,4 +1,5 @@
 import {Component, ElementRef, EventEmitter, inject, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {TooltipModule} from "primeng/tooltip";
 import {Book, ReadStatus} from '../../../model/book.model';
 import {Button} from 'primeng/button';
 import {MenuModule} from 'primeng/menu';
@@ -29,7 +30,7 @@ import {ResetProgressTypes} from '../../../../shared/constants/reset-progress-ty
   selector: 'app-book-card',
   templateUrl: './book-card.component.html',
   styleUrls: ['./book-card.component.scss'],
-  imports: [Button, MenuModule, CheckboxModule, FormsModule, NgClass, TieredMenu, ProgressBar],
+  imports: [Button, MenuModule, CheckboxModule, FormsModule, NgClass, TieredMenu, ProgressBar, TooltipModule],
   standalone: true
 })
 export class BookCardComponent implements OnInit, OnDestroy {

--- a/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.html
@@ -48,7 +48,7 @@
             (click)="toggleMetadataLock(metadata)">
           </p-button>
         </td>
-        <td (click)="openMetadataCenter(book.id)">
+        <td (click)="openMetadataCenter(book.id)" class="cursor-pointer">
           <img [attr.src]="urlHelper.getCoverUrl(metadata.bookId, metadata.coverUpdatedOn)" alt="Book Cover" class="size-7"/>
         </td>
 
@@ -68,7 +68,12 @@
               </span>
             </td>
           } @else {
-            <td [title]="getCellValue(metadata, book, col.field)" class="overflow-hidden truncate text-right min-w-[6rem] max-w-[12rem]">
+            <td [title]="getCellValue(metadata, book, col.field)"
+                tooltipPosition="right"
+                autoHide="false"
+                tooltipStyleClass="text-xs text-center"
+                [pTooltip]="getCellValue(metadata, book, col.field)?.toString()"
+                class="overflow-hidden truncate text-right min-w-[6rem] max-w-[12rem]">
               {{ getCellValue(metadata, book, col.field) }}
             </td>
           }

--- a/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.ts
@@ -3,6 +3,7 @@ import {TableModule} from 'primeng/table';
 import {DatePipe} from '@angular/common';
 import {Rating} from 'primeng/rating';
 import {FormsModule} from '@angular/forms';
+import {TooltipModule} from "primeng/tooltip";
 import {Book, BookMetadata} from '../../../model/book.model';
 import {SortOption} from '../../../model/sort.model';
 import {UrlHelperService} from '../../../../utilities/service/url-helper.service';
@@ -24,7 +25,8 @@ import {take, takeUntil} from 'rxjs/operators';
     TableModule,
     Rating,
     FormsModule,
-    Button
+    Button,
+    TooltipModule
   ],
   styleUrls: ['./book-table.component.scss'],
   providers: [DatePipe]

--- a/booklore-ui/src/app/book/components/book-card-lite/book-card-lite-component.html
+++ b/booklore-ui/src/app/book/components/book-card-lite/book-card-lite-component.html
@@ -1,4 +1,8 @@
 <div class="book-cover-wrapper"
+     tooltipPosition="top"
+     autoHide="false"
+     tooltipStyleClass="text-xs text-center"
+     [pTooltip]="book.metadata?.title"
      (mouseenter)="isHovered = true"
      (mouseleave)="isHovered = false">
   <img

--- a/booklore-ui/src/app/book/components/book-card-lite/book-card-lite-component.ts
+++ b/booklore-ui/src/app/book/components/book-card-lite/book-card-lite-component.ts
@@ -8,12 +8,14 @@ import {filter, Subject} from 'rxjs';
 import {NgClass} from '@angular/common';
 import {BookMetadataHostService} from '../../../utilities/service/book-metadata-host-service';
 import {takeUntil} from 'rxjs/operators';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'app-book-card-lite-component',
   imports: [
     Button,
-    NgClass
+    NgClass,
+    TooltipModule
   ],
   templateUrl: './book-card-lite-component.html',
   styleUrl: './book-card-lite-component.scss'


### PR DESCRIPTION
this will add tooltips on:

- library book thumbnails
- library table cells
- thumbnail buttons (info & read)
- `similar books`

<img width="317" height="501" alt="image" src="https://github.com/user-attachments/assets/1149f184-5688-4a53-9244-adf28feb76c9" />
