### PR TITLE
feat: add itunes metadata service for cover images

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/BookParserConfig.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/BookParserConfig.java
@@ -12,13 +12,15 @@ public class BookParserConfig {
 
     @Bean
     public Map<MetadataProvider, BookParser> parserMap(GoogleParser googleParser, AmazonBookParser amazonBookParser,
-                                                       GoodReadsParser goodReadsParser, HardcoverParser hardcoverParser, ComicvineBookParser comicvineBookParser) {
+                                                       GoodReadsParser goodReadsParser, HardcoverParser hardcoverParser, 
+                                                       ComicvineBookParser comicvineBookParser, iTunesParser iTunesParser) {
         return Map.of(
                 MetadataProvider.Amazon, amazonBookParser,
                 MetadataProvider.GoodReads, goodReadsParser,
                 MetadataProvider.Google, googleParser,
                 MetadataProvider.Hardcover, hardcoverParser,
-                MetadataProvider.Comicvine, comicvineBookParser
+                MetadataProvider.Comicvine, comicvineBookParser,
+                MetadataProvider.iTunes, iTunesParser
         );
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/settings/MetadataProviderSettings.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/settings/MetadataProviderSettings.java
@@ -1,5 +1,6 @@
 package com.adityachandel.booklore.model.dto.settings;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -9,6 +10,8 @@ public class MetadataProviderSettings {
     private Goodreads goodReads;
     private Hardcover hardcover;
     private Comicvine comicvine;
+    @JsonProperty("iTunes")
+    private iTunes iTunes;
 
     @Data
     public static class Amazon {
@@ -36,5 +39,11 @@ public class MetadataProviderSettings {
     public static class Comicvine {
         private boolean enabled;
         private String apiKey;
+    }
+    
+    @Data
+    public static class iTunes {
+        private boolean enabled;
+        private String country = "us";
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/enums/MetadataProvider.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/enums/MetadataProvider.java
@@ -1,5 +1,5 @@
 package com.adityachandel.booklore.model.enums;
 
 public enum MetadataProvider {
-    Amazon, GoodReads, Google, Hardcover, Comicvine
+    Amazon, GoodReads, Google, Hardcover, Comicvine, iTunes
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/appsettings/SettingPersistenceHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/appsettings/SettingPersistenceHelper.java
@@ -42,6 +42,16 @@ public class SettingPersistenceHelper {
             try {
                 return objectMapper.readValue(json, clazz);
             } catch (JsonProcessingException e) {
+                // Handle migration case: if parsing fails (e.g., missing new fields like iTunes), 
+                // fall back to defaults and persist them
+                if (defaultValue != null && persistDefault) {
+                    try {
+                        saveDefaultSetting(key, objectMapper.writeValueAsString(defaultValue));
+                        return defaultValue;
+                    } catch (JsonProcessingException saveException) {
+                        throw new RuntimeException("Failed to persist default for " + key, saveException);
+                    }
+                }
                 throw new RuntimeException("Failed to parse " + key, e);
             }
         }
@@ -81,16 +91,21 @@ public class SettingPersistenceHelper {
         defaultComicvine.setEnabled(false);
         defaultComicvine.setApiKey(null);
 
+        MetadataProviderSettings.iTunes defaultiTunes = new MetadataProviderSettings.iTunes();
+        defaultiTunes.setEnabled(true);
+        defaultiTunes.setCountry("us");
+
         defaultMetadataProviderSettings.setAmazon(defaultAmazon);
         defaultMetadataProviderSettings.setGoogle(defaultGoogle);
         defaultMetadataProviderSettings.setGoodReads(defaultGoodreads);
         defaultMetadataProviderSettings.setHardcover(defaultHardcover);
         defaultMetadataProviderSettings.setComicvine(defaultComicvine);
+        defaultMetadataProviderSettings.setITunes(defaultiTunes);
 
         return defaultMetadataProviderSettings;
     }
 
-    MetadataRefreshOptions getDefaultMetadataRefreshOptions() {
+    public MetadataRefreshOptions getDefaultMetadataRefreshOptions() {
         MetadataRefreshOptions.FieldProvider titleProviders =
                 new MetadataRefreshOptions.FieldProvider(null, MetadataProvider.Google, MetadataProvider.Amazon, MetadataProvider.GoodReads);
         MetadataRefreshOptions.FieldProvider subtitleProviders =
@@ -118,7 +133,7 @@ public class SettingPersistenceHelper {
         MetadataRefreshOptions.FieldProvider categoriesProviders =
                 new MetadataRefreshOptions.FieldProvider(null, MetadataProvider.Google, MetadataProvider.Amazon, MetadataProvider.GoodReads);
         MetadataRefreshOptions.FieldProvider coverProviders =
-                new MetadataRefreshOptions.FieldProvider(null, MetadataProvider.Google, MetadataProvider.Amazon, MetadataProvider.GoodReads);
+                new MetadataRefreshOptions.FieldProvider(MetadataProvider.iTunes, MetadataProvider.Google, MetadataProvider.Amazon, MetadataProvider.GoodReads);
 
         MetadataRefreshOptions.FieldOptions fieldOptions = new MetadataRefreshOptions.FieldOptions(
                 titleProviders,

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
@@ -158,21 +158,33 @@ public class BookMetadataUpdater {
     private void updateAuthorsIfNeeded(BookMetadata m, BookMetadataEntity e, MetadataClearFlags clear) {
         if (Boolean.TRUE.equals(e.getAuthorsLocked())) {
             // Locked — do nothing
-        } else if (clear.isAuthors()) {
-            if (e.getAuthors() == null) {
-                e.setAuthors(new HashSet<>());
-            } else {
-                e.getAuthors().clear();
-            }
+            return;
+        }
+        
+        // Ensure authors collection is initialized
+        if (e.getAuthors() == null) {
+            e.setAuthors(new HashSet<>());
+        }
+        
+        if (clear.isAuthors()) {
+            e.getAuthors().clear();
         } else if (shouldUpdateField(false, m.getAuthors()) && m.getAuthors() != null) {
-            if (e.getAuthors() == null) {
-                e.setAuthors(new HashSet<>());
+            Set<AuthorEntity> newAuthors = new HashSet<>();
+            for (String authorName : m.getAuthors()) {
+                if (authorName != null && !authorName.isBlank()) {
+                    AuthorEntity author = authorRepository.findByName(authorName)
+                            .orElseGet(() -> {
+                                try {
+                                    return authorRepository.save(AuthorEntity.builder().name(authorName).build());
+                                } catch (Exception ex) {
+                                    // In case of concurrent creation, try to find again
+                                    return authorRepository.findByName(authorName)
+                                            .orElseThrow(() -> new RuntimeException("Failed to create or find author: " + authorName, ex));
+                                }
+                            });
+                    newAuthors.add(author);
+                }
             }
-            Set<AuthorEntity> newAuthors = m.getAuthors().stream()
-                    .filter(a -> a != null && !a.isBlank())
-                    .map(name -> authorRepository.findByName(name)
-                            .orElseGet(() -> authorRepository.save(AuthorEntity.builder().name(name).build())))
-                    .collect(Collectors.toSet());
             e.getAuthors().clear();
             e.getAuthors().addAll(newAuthors);
         }
@@ -182,9 +194,12 @@ public class BookMetadataUpdater {
         if (Boolean.TRUE.equals(e.getCategoriesLocked())) {
             return;
         }
+        
+        // Ensure categories collection is initialized
         if (e.getCategories() == null) {
             e.setCategories(new HashSet<>());
         }
+        
         if (clear.isCategories()) {
             e.getCategories().clear();
         } else if (shouldUpdateField(false, m.getCategories()) && m.getCategories() != null) {
@@ -193,18 +208,36 @@ public class BookMetadataUpdater {
                 for (String name : m.getCategories()) {
                     if (name == null || name.isBlank()) continue;
                     CategoryEntity entity = categoryRepository.findByName(name)
-                            .orElseGet(() -> categoryRepository.save(CategoryEntity.builder().name(name).build()));
+                            .orElseGet(() -> {
+                                try {
+                                    return categoryRepository.save(CategoryEntity.builder().name(name).build());
+                                } catch (Exception ex) {
+                                    // In case of concurrent creation, try to find again
+                                    return categoryRepository.findByName(name)
+                                            .orElseThrow(() -> new RuntimeException("Failed to create or find category: " + name, ex));
+                                }
+                            });
                     existing.add(entity);
                 }
             } else {
-                Set<CategoryEntity> existing = e.getCategories();
-                existing.clear();
-                Set<CategoryEntity> result = m.getCategories().stream()
-                        .filter(n -> n != null && !n.isBlank())
-                        .map(name -> categoryRepository.findByName(name)
-                                .orElseGet(() -> categoryRepository.save(CategoryEntity.builder().name(name).build())))
-                        .collect(Collectors.toSet());
-                existing.addAll(result);
+                Set<CategoryEntity> newCategories = new HashSet<>();
+                for (String name : m.getCategories()) {
+                    if (name != null && !name.isBlank()) {
+                        CategoryEntity entity = categoryRepository.findByName(name)
+                                .orElseGet(() -> {
+                                    try {
+                                        return categoryRepository.save(CategoryEntity.builder().name(name).build());
+                                    } catch (Exception ex) {
+                                        // In case of concurrent creation, try to find again
+                                        return categoryRepository.findByName(name)
+                                                .orElseThrow(() -> new RuntimeException("Failed to create or find category: " + name, ex));
+                                    }
+                                });
+                        newCategories.add(entity);
+                    }
+                }
+                e.getCategories().clear();
+                e.getCategories().addAll(newCategories);
             }
         }
     }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
@@ -94,9 +94,19 @@ public class MetadataRefreshService {
                 checkForInterruption(jobId, task, bookIds.size());
                 int finalCompletedCount = completedCount;
                 txTemplate.execute(status -> {
-                    BookEntity book = bookRepository.findAllWithMetadataByIds(Collections.singleton(bookId))
-                            .stream().findFirst()
+                    BookEntity book = bookRepository.findById(bookId)
                             .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+                    
+                    // Initialize lazy collections to prevent detached entity issues
+                    if (book.getMetadata() != null) {
+                        if (book.getMetadata().getAuthors() != null) {
+                            book.getMetadata().getAuthors().size(); // Force load
+                        }
+                        if (book.getMetadata().getCategories() != null) {
+                            book.getMetadata().getCategories().size(); // Force load
+                        }
+                    }
+                    
                     try {
                         checkForInterruption(jobId, task, bookIds.size());
                         if (book.getMetadata().areAllFieldsLocked()) {
@@ -131,7 +141,13 @@ public class MetadataRefreshService {
                         log.error("Metadata update failed for book: {}", book.getFileName(), e);
                         sendTaskNotification(jobId, String.format("Failed to process: %s - %s", book.getMetadata().getTitle(), e.getMessage()), TaskStatus.FAILED);
                     }
-                    bookRepository.saveAndFlush(book);
+                    try {
+                        bookRepository.saveAndFlush(book);
+                    } catch (Exception e) {
+                        log.error("Failed to save book entity for book ID {}: {}", book.getId(), e.getMessage());
+                        status.setRollbackOnly();
+                        throw e;
+                    }
                     return null;
                 });
                 completedCount++;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/iTunesParser.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/iTunesParser.java
@@ -1,0 +1,112 @@
+package com.adityachandel.booklore.service.metadata.parser;
+
+import com.adityachandel.booklore.model.dto.Book;
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.dto.request.FetchMetadataRequest;
+import com.adityachandel.booklore.model.enums.MetadataProvider;
+import com.adityachandel.booklore.service.appsettings.AppSettingService;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesApiService;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesSearchRequest;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesSearchResponse;
+import com.adityachandel.booklore.util.BookUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class iTunesParser implements BookParser {
+    
+    private final iTunesApiService iTunesApiService;
+    private final AppSettingService appSettingService;
+    
+    @Override
+    public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
+        String title = fetchMetadataRequest.getTitle();
+        
+        // Use filename as fallback if title is null or empty
+        if (title == null || title.trim().isEmpty()) {
+            if (book.getFileName() != null && !book.getFileName().trim().isEmpty()) {
+                title = BookUtils.cleanAndTruncateSearchTerm(BookUtils.cleanFileName(book.getFileName()));
+                log.info("iTunes: Using cleaned filename as search term: {}", title);
+            } else {
+                log.warn("iTunes: Both title and filename are null or empty, skipping search");
+                return List.of();
+            }
+        }
+        
+        log.info("iTunes: Fetching cover metadata for book {}", title);
+        
+        var iTunesSettings = appSettingService.getAppSettings().getMetadataProviderSettings().getITunes();
+        if (!iTunesSettings.isEnabled()) {
+            log.debug("iTunes provider is disabled");
+            return List.of();
+        }
+        
+        List<BookMetadata> results = new ArrayList<>();
+        String country = iTunesSettings.getCountry();
+        
+        // Strategy 1: Primary search with title + author and ebook entity
+        if (fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()) {
+            String fullTerm = title + " " + fetchMetadataRequest.getAuthor();
+            results.addAll(searchForCovers(fullTerm, "ebook", country));
+        }
+        
+        // Strategy 2: Fallback search with title only and ebook entity
+        if (results.isEmpty()) {
+            results.addAll(searchForCovers(title, "ebook", country));
+        }
+        
+        // Strategy 3: Alternative search with title + author and audiobook entity
+        if (results.isEmpty() && fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()) {
+            String fullTerm = title + " " + fetchMetadataRequest.getAuthor();
+            results.addAll(searchForCovers(fullTerm, "audiobook", country));
+        }
+        
+        // Strategy 4: Alternative search with title only and audiobook entity
+        if (results.isEmpty()) {
+            results.addAll(searchForCovers(title, "audiobook", country));
+        }
+        
+        log.info("iTunes: Found {} cover results for '{}'", results.size(), title);
+        return results;
+    }
+    
+    @Override
+    public BookMetadata fetchTopMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
+        List<BookMetadata> bookMetadata = fetchMetadata(book, fetchMetadataRequest);
+        return bookMetadata.isEmpty() ? null : bookMetadata.getFirst();
+    }
+    
+    private List<BookMetadata> searchForCovers(String searchTerm, String entity, String country) {
+        iTunesSearchRequest request = iTunesSearchRequest.builder()
+                .term(searchTerm)
+                .entity(entity)
+                .country(country)
+                .limit(10)
+                .build();
+        
+        Optional<iTunesSearchResponse> response = iTunesApiService.search(request);
+        if (response.isEmpty()) {
+            return List.of();
+        }
+        
+        List<String> artworkUrls = iTunesApiService.getHighResolutionArtworkUrls(response.get());
+        
+        return artworkUrls.stream()
+                .map(this::createCoverOnlyMetadata)
+                .toList();
+    }
+    
+    private BookMetadata createCoverOnlyMetadata(String artworkUrl) {
+        BookMetadata metadata = new BookMetadata();
+        metadata.setThumbnailUrl(artworkUrl);
+        metadata.setProvider(MetadataProvider.iTunes);
+        return metadata;
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesApiService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesApiService.java
@@ -1,0 +1,92 @@
+package com.adityachandel.booklore.service.metadata.parser.itunes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class iTunesApiService {
+    
+    private static final String ITUNES_SEARCH_API_URL = "https://itunes.apple.com/search";
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    
+    private final ObjectMapper objectMapper;
+    
+    public Optional<iTunesSearchResponse> search(iTunesSearchRequest request) {
+        try {
+            URI uri = buildSearchUri(request);
+            log.debug("iTunes API request: {}", uri);
+            
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("User-Agent", "BookLore/1.0")
+                    .GET()
+                    .build();
+            
+            HttpResponse<String> response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            
+            if (response.statusCode() == 200) {
+                iTunesSearchResponse searchResponse = objectMapper.readValue(response.body(), iTunesSearchResponse.class);
+                log.debug("iTunes API returned {} results", searchResponse.getResultCount());
+                return Optional.of(searchResponse);
+            } else {
+                log.warn("iTunes API request failed with status {}: {}", response.statusCode(), response.body());
+                return Optional.empty();
+            }
+            
+        } catch (IOException | InterruptedException e) {
+            log.error("Error calling iTunes API for term: {}", request.getTerm(), e);
+            return Optional.empty();
+        }
+    }
+    
+    public List<String> getHighResolutionArtworkUrls(iTunesSearchResponse response) {
+        return response.getResults().stream()
+                .map(iTunesSearchResponse.iTunesItem::getArtworkUrl100)
+                .filter(url -> url != null && !url.isEmpty())
+                .map(this::convertToHighResolution)
+                .toList();
+    }
+    
+    private String convertToHighResolution(String originalUrl) {
+        if (originalUrl.contains("100x100bb")) {
+            return originalUrl.replace("100x100bb", "600x600bb");
+        }
+        if (originalUrl.contains("100x100")) {
+            return originalUrl.replace("100x100", "600x600");
+        }
+        return originalUrl;
+    }
+    
+    private URI buildSearchUri(iTunesSearchRequest request) {
+        String term = request.getTerm();
+        if (term == null || term.trim().isEmpty()) {
+            throw new IllegalArgumentException("Search term cannot be null or empty");
+        }
+        
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(ITUNES_SEARCH_API_URL)
+                .queryParam("term", URLEncoder.encode(term.trim(), StandardCharsets.UTF_8))
+                .queryParam("entity", request.getEntity())
+                .queryParam("country", request.getCountry())
+                .queryParam("limit", request.getLimit() != null ? request.getLimit() : 25);
+        
+        return builder.build().toUri();
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesSearchRequest.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesSearchRequest.java
@@ -1,0 +1,13 @@
+package com.adityachandel.booklore.service.metadata.parser.itunes;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class iTunesSearchRequest {
+    private String term;
+    private String entity;
+    private String country;
+    private Integer limit;
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesSearchResponse.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesSearchResponse.java
@@ -1,0 +1,37 @@
+package com.adityachandel.booklore.service.metadata.parser.itunes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class iTunesSearchResponse {
+    
+    @JsonProperty("resultCount")
+    private int resultCount;
+    
+    @JsonProperty("results")
+    private List<iTunesItem> results;
+    
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class iTunesItem {
+        @JsonProperty("trackId")
+        private Long trackId;
+        
+        @JsonProperty("trackName")
+        private String trackName;
+        
+        @JsonProperty("artistName")
+        private String artistName;
+        
+        @JsonProperty("artworkUrl100")
+        private String artworkUrl100;
+        
+        @JsonProperty("kind")
+        private String kind;
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/migration/MetadataProviderMigrationService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/migration/MetadataProviderMigrationService.java
@@ -1,0 +1,69 @@
+package com.adityachandel.booklore.service.migration;
+
+import com.adityachandel.booklore.model.dto.settings.AppSettingKey;
+import com.adityachandel.booklore.service.appsettings.SettingPersistenceHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetadataProviderMigrationService implements ApplicationRunner {
+    
+    private final SettingPersistenceHelper settingPersistenceHelper;
+    
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        migrateMetadataProviderSettings();
+        migrateQuickBookMatchSettings();
+    }
+    
+    private void migrateMetadataProviderSettings() {
+        try {
+            // Try to trigger settings loading which will handle migration via the enhanced error handling
+            settingPersistenceHelper.getJsonSetting(
+                settingPersistenceHelper.appSettingsRepository.findAll().stream()
+                    .collect(java.util.stream.Collectors.toMap(entity -> entity.getName(), entity -> entity.getVal())),
+                AppSettingKey.METADATA_PROVIDER_SETTINGS,
+                com.adityachandel.booklore.model.dto.settings.MetadataProviderSettings.class,
+                settingPersistenceHelper.getDefaultMetadataProviderSettings(),
+                true
+            );
+            log.info("Metadata provider settings migration completed successfully");
+        } catch (Exception e) {
+            log.warn("Metadata provider settings migration encountered an issue: {}", e.getMessage());
+            // Force reset by deleting the corrupted setting
+            var corruptedSetting = settingPersistenceHelper.appSettingsRepository.findByName(AppSettingKey.METADATA_PROVIDER_SETTINGS.toString());
+            if (corruptedSetting != null) {
+                settingPersistenceHelper.appSettingsRepository.delete(corruptedSetting);
+                log.info("Deleted corrupted metadata provider settings - will be recreated with defaults");
+            }
+        }
+    }
+    
+    private void migrateQuickBookMatchSettings() {
+        try {
+            // Try to trigger settings loading which will handle migration via the enhanced error handling
+            settingPersistenceHelper.getJsonSetting(
+                settingPersistenceHelper.appSettingsRepository.findAll().stream()
+                    .collect(java.util.stream.Collectors.toMap(entity -> entity.getName(), entity -> entity.getVal())),
+                AppSettingKey.QUICK_BOOK_MATCH,
+                com.adityachandel.booklore.model.dto.request.MetadataRefreshOptions.class,
+                settingPersistenceHelper.getDefaultMetadataRefreshOptions(),
+                true
+            );
+            log.info("Quick book match settings migration completed successfully");
+        } catch (Exception e) {
+            log.warn("Quick book match settings migration encountered an issue: {}", e.getMessage());
+            // Force reset by deleting the corrupted setting
+            var corruptedSetting = settingPersistenceHelper.appSettingsRepository.findByName(AppSettingKey.QUICK_BOOK_MATCH.toString());
+            if (corruptedSetting != null) {
+                settingPersistenceHelper.appSettingsRepository.delete(corruptedSetting);
+                log.info("Deleted corrupted quick book match settings - will be recreated with defaults");
+            }
+        }
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/iTunesParserTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/iTunesParserTest.java
@@ -1,0 +1,227 @@
+package com.adityachandel.booklore.service.metadata.parser;
+
+import com.adityachandel.booklore.model.dto.Book;
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.dto.request.FetchMetadataRequest;
+import com.adityachandel.booklore.model.dto.settings.AppSettings;
+import com.adityachandel.booklore.model.dto.settings.MetadataProviderSettings;
+import com.adityachandel.booklore.model.enums.MetadataProvider;
+import com.adityachandel.booklore.service.appsettings.AppSettingService;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesApiService;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesSearchRequest;
+import com.adityachandel.booklore.service.metadata.parser.itunes.iTunesSearchResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class iTunesParserTest {
+
+    @Mock
+    private iTunesApiService iTunesApiService;
+    
+    @Mock
+    private AppSettingService appSettingService;
+    
+    private iTunesParser iTunesParser;
+    
+    private Book testBook;
+    private FetchMetadataRequest testRequest;
+
+    @BeforeEach
+    void setUp() {
+        iTunesParser = new iTunesParser(iTunesApiService, appSettingService);
+        
+        testBook = Book.builder().build();
+        testRequest = FetchMetadataRequest.builder()
+                .title("The Great Gatsby")
+                .author("F. Scott Fitzgerald")
+                .build();
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenProviderDisabled() {
+        // Given
+        MetadataProviderSettings.iTunes iTunesSettings = new MetadataProviderSettings.iTunes();
+        iTunesSettings.setEnabled(false);
+        
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        providerSettings.setITunes(iTunesSettings);
+        
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataProviderSettings(providerSettings);
+        
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // When
+        List<BookMetadata> result = iTunesParser.fetchMetadata(testBook, testRequest);
+
+        // Then
+        assertTrue(result.isEmpty());
+        verify(iTunesApiService, never()).search(any());
+    }
+
+    @Test
+    void shouldReturnCoverMetadataWhenResultsFound() {
+        // Given
+        MetadataProviderSettings.iTunes iTunesSettings = new MetadataProviderSettings.iTunes();
+        iTunesSettings.setEnabled(true);
+        iTunesSettings.setCountry("us");
+        
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        providerSettings.setITunes(iTunesSettings);
+        
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataProviderSettings(providerSettings);
+        
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // Mock iTunes API response
+        iTunesSearchResponse.iTunesItem item = new iTunesSearchResponse.iTunesItem();
+        item.setArtworkUrl100("https://is1-ssl.mzstatic.com/image/thumb/100x100bb.jpg");
+        item.setTrackName("The Great Gatsby");
+        item.setArtistName("F. Scott Fitzgerald");
+        
+        iTunesSearchResponse response = new iTunesSearchResponse();
+        response.setResultCount(1);
+        response.setResults(List.of(item));
+        
+        when(iTunesApiService.search(any(iTunesSearchRequest.class))).thenReturn(Optional.of(response));
+        when(iTunesApiService.getHighResolutionArtworkUrls(response))
+                .thenReturn(List.of("https://is1-ssl.mzstatic.com/image/thumb/600x600bb.jpg"));
+
+        // When
+        List<BookMetadata> result = iTunesParser.fetchMetadata(testBook, testRequest);
+
+        // Then
+        assertFalse(result.isEmpty());
+        BookMetadata metadata = result.get(0);
+        assertEquals("https://is1-ssl.mzstatic.com/image/thumb/600x600bb.jpg", metadata.getThumbnailUrl());
+        assertEquals(MetadataProvider.iTunes, metadata.getProvider());
+        
+        // Should only have thumbnail URL populated (cover-only provider)
+        assertNull(metadata.getTitle());
+        assertNull(metadata.getAuthors());
+        assertNull(metadata.getDescription());
+    }
+
+    @Test
+    void shouldFallbackToAudiobookEntityWhenEbookReturnsNoResults() {
+        // Given
+        MetadataProviderSettings.iTunes iTunesSettings = new MetadataProviderSettings.iTunes();
+        iTunesSettings.setEnabled(true);
+        iTunesSettings.setCountry("us");
+        
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        providerSettings.setITunes(iTunesSettings);
+        
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataProviderSettings(providerSettings);
+        
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // Mock empty results for first few searches, successful for audiobook
+        iTunesSearchResponse emptyResponse = new iTunesSearchResponse();
+        emptyResponse.setResultCount(0);
+        emptyResponse.setResults(List.of());
+        
+        iTunesSearchResponse.iTunesItem item = new iTunesSearchResponse.iTunesItem();
+        item.setArtworkUrl100("https://audiobook-cover.jpg");
+        
+        iTunesSearchResponse audiobookResponse = new iTunesSearchResponse();
+        audiobookResponse.setResultCount(1);
+        audiobookResponse.setResults(List.of(item));
+        
+        // Return empty first, then successful result
+        when(iTunesApiService.search(any(iTunesSearchRequest.class)))
+                .thenReturn(Optional.of(emptyResponse))
+                .thenReturn(Optional.of(emptyResponse))
+                .thenReturn(Optional.of(emptyResponse))
+                .thenReturn(Optional.of(audiobookResponse));
+        
+        when(iTunesApiService.getHighResolutionArtworkUrls(emptyResponse))
+                .thenReturn(List.of());
+        when(iTunesApiService.getHighResolutionArtworkUrls(audiobookResponse))
+                .thenReturn(List.of("https://audiobook-cover-600x600.jpg"));
+
+        // When
+        List<BookMetadata> result = iTunesParser.fetchMetadata(testBook, testRequest);
+
+        // Then
+        assertFalse(result.isEmpty());
+        assertEquals("https://audiobook-cover-600x600.jpg", result.get(0).getThumbnailUrl());
+        verify(iTunesApiService, times(4)).search(any());
+    }
+
+    @Test
+    void shouldReturnTopMetadataFromList() {
+        // Given
+        MetadataProviderSettings.iTunes iTunesSettings = new MetadataProviderSettings.iTunes();
+        iTunesSettings.setEnabled(true);
+        iTunesSettings.setCountry("us");
+        
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        providerSettings.setITunes(iTunesSettings);
+        
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataProviderSettings(providerSettings);
+        
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // Mock multiple results
+        iTunesSearchResponse.iTunesItem item1 = new iTunesSearchResponse.iTunesItem();
+        item1.setArtworkUrl100("https://first-cover.jpg");
+        
+        iTunesSearchResponse.iTunesItem item2 = new iTunesSearchResponse.iTunesItem();
+        item2.setArtworkUrl100("https://second-cover.jpg");
+        
+        iTunesSearchResponse response = new iTunesSearchResponse();
+        response.setResultCount(2);
+        response.setResults(List.of(item1, item2));
+        
+        when(iTunesApiService.search(any(iTunesSearchRequest.class))).thenReturn(Optional.of(response));
+        when(iTunesApiService.getHighResolutionArtworkUrls(response))
+                .thenReturn(List.of("https://first-cover-600x600.jpg", "https://second-cover-600x600.jpg"));
+
+        // When
+        BookMetadata topResult = iTunesParser.fetchTopMetadata(testBook, testRequest);
+
+        // Then
+        assertNotNull(topResult);
+        assertEquals("https://first-cover-600x600.jpg", topResult.getThumbnailUrl());
+        assertEquals(MetadataProvider.iTunes, topResult.getProvider());
+    }
+
+    @Test
+    void shouldReturnNullWhenNoResultsFound() {
+        // Given
+        MetadataProviderSettings.iTunes iTunesSettings = new MetadataProviderSettings.iTunes();
+        iTunesSettings.setEnabled(true);
+        iTunesSettings.setCountry("us");
+        
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        providerSettings.setITunes(iTunesSettings);
+        
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataProviderSettings(providerSettings);
+        
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+        when(iTunesApiService.search(any(iTunesSearchRequest.class))).thenReturn(Optional.empty());
+
+        // When
+        BookMetadata result = iTunesParser.fetchTopMetadata(testBook, testRequest);
+
+        // Then
+        assertNull(result);
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesApiServiceTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/itunes/iTunesApiServiceTest.java
@@ -1,0 +1,80 @@
+package com.adityachandel.booklore.service.metadata.parser.itunes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class iTunesApiServiceTest {
+
+    private iTunesApiService iTunesApiService;
+
+    @BeforeEach
+    void setUp() {
+        iTunesApiService = new iTunesApiService(new ObjectMapper());
+    }
+
+    @Test
+    void shouldConvertToHighResolutionUrls() {
+        // Given
+        iTunesSearchResponse.iTunesItem item1 = new iTunesSearchResponse.iTunesItem();
+        item1.setArtworkUrl100("https://is1-ssl.mzstatic.com/image/thumb/100x100bb.jpg");
+        
+        iTunesSearchResponse.iTunesItem item2 = new iTunesSearchResponse.iTunesItem();
+        item2.setArtworkUrl100("https://is2-ssl.mzstatic.com/image/thumb/100x100.jpg");
+        
+        iTunesSearchResponse.iTunesItem item3 = new iTunesSearchResponse.iTunesItem();
+        item3.setArtworkUrl100("https://is3-ssl.mzstatic.com/image/thumb/300x300.jpg");
+        
+        iTunesSearchResponse response = new iTunesSearchResponse();
+        response.setResults(List.of(item1, item2, item3));
+
+        // When
+        List<String> highResUrls = iTunesApiService.getHighResolutionArtworkUrls(response);
+
+        // Then
+        assertEquals(3, highResUrls.size());
+        assertEquals("https://is1-ssl.mzstatic.com/image/thumb/600x600bb.jpg", highResUrls.get(0));
+        assertEquals("https://is2-ssl.mzstatic.com/image/thumb/600x600.jpg", highResUrls.get(1));
+        assertEquals("https://is3-ssl.mzstatic.com/image/thumb/300x300.jpg", highResUrls.get(2)); // No conversion
+    }
+
+    @Test
+    void shouldFilterOutNullAndEmptyArtworkUrls() {
+        // Given
+        iTunesSearchResponse.iTunesItem item1 = new iTunesSearchResponse.iTunesItem();
+        item1.setArtworkUrl100("https://valid-url.jpg");
+        
+        iTunesSearchResponse.iTunesItem item2 = new iTunesSearchResponse.iTunesItem();
+        item2.setArtworkUrl100(null);
+        
+        iTunesSearchResponse.iTunesItem item3 = new iTunesSearchResponse.iTunesItem();
+        item3.setArtworkUrl100("");
+        
+        iTunesSearchResponse response = new iTunesSearchResponse();
+        response.setResults(List.of(item1, item2, item3));
+
+        // When
+        List<String> highResUrls = iTunesApiService.getHighResolutionArtworkUrls(response);
+
+        // Then
+        assertEquals(1, highResUrls.size());
+        assertEquals("https://valid-url.jpg", highResUrls.get(0));
+    }
+
+    @Test
+    void shouldHandleEmptyResponse() {
+        // Given
+        iTunesSearchResponse response = new iTunesSearchResponse();
+        response.setResults(List.of());
+
+        // When
+        List<String> highResUrls = iTunesApiService.getHighResolutionArtworkUrls(response);
+
+        // Then
+        assertTrue(highResUrls.isEmpty());
+    }
+}

--- a/booklore-ui/src/app/core/model/app-settings.model.ts
+++ b/booklore-ui/src/app/core/model/app-settings.model.ts
@@ -47,6 +47,7 @@ export interface MetadataProviderSettings {
   goodReads: Goodreads;
   hardcover: Hardcover;
   comicvine: Comicvine;
+  iTunes: iTunes;
 }
 
 export interface Amazon {
@@ -71,6 +72,11 @@ export interface Hardcover {
 export interface Comicvine {
   enabled: boolean;
   apiKey: string;
+}
+
+export interface iTunes {
+  enabled: boolean;
+  country: string;
 }
 
 export interface MetadataPersistenceSettings {

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-searcher/metadata-searcher.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-searcher/metadata-searcher.component.ts
@@ -86,7 +86,14 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy {
           const providerSettings = settings?.metadataProviderSettings ?? {};
           this.providers = Object.entries(providerSettings)
             .filter(([_, value]) => !!value && typeof value === 'object' && 'enabled' in value && (value as any).enabled)
-            .map(([key]) => key.charAt(0).toUpperCase() + key.slice(1));
+            .map(([key]) => {
+              // Handle special cases for provider names that don't follow simple capitalization
+              const providerNameMap: {[key: string]: string} = {
+                'iTunes': 'iTunes',
+                'goodReads': 'GoodReads'
+              };
+              return providerNameMap[key] || key.charAt(0).toUpperCase() + key.slice(1);
+            });
 
           this.resetFormFromBook(book!);
 

--- a/booklore-ui/src/app/metadata/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.ts
+++ b/booklore-ui/src/app/metadata/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges
+  Component, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges
 } from '@angular/core';
 import {Select, SelectChangeEvent} from 'primeng/select';
 import {FormsModule} from '@angular/forms';
@@ -13,6 +13,8 @@ import {
   MetadataRefreshOptions
 } from '../../model/request/metadata-refresh-options.model';
 import {Tooltip} from 'primeng/tooltip';
+import {AppSettingsService} from '../../../core/service/app-settings.service';
+import {filter, take} from 'rxjs/operators';
 
 @Component({
   selector: 'app-metadata-advanced-fetch-options',
@@ -21,7 +23,7 @@ import {Tooltip} from 'primeng/tooltip';
   styleUrl: './metadata-advanced-fetch-options.component.scss',
   standalone: true
 })
-export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
+export class MetadataAdvancedFetchOptionsComponent implements OnChanges, OnInit {
 
   @Output() metadataOptionsSubmitted = new EventEmitter<MetadataRefreshOptions>();
   @Input() currentMetadataOptions!: MetadataRefreshOptions;
@@ -32,7 +34,7 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
     'seriesName', 'seriesNumber', 'seriesTotal', 'isbn13', 'isbn10',
     'language', 'categories', 'cover'
   ];
-  providers: string[] = ['Amazon', 'Google', 'GoodReads', 'Hardcover', 'Comicvine'];
+  providers: string[] = [];
 
   refreshCovers: boolean = false;
   mergeCategories: boolean = false;
@@ -46,6 +48,28 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
   fieldOptions: FieldOptions = this.initializeFieldOptions();
 
   private messageService = inject(MessageService);
+  private appSettingsService = inject(AppSettingsService);
+
+  ngOnInit(): void {
+    this.appSettingsService.appSettings$
+      .pipe(
+        filter(settings => settings != null),
+        take(1)
+      )
+      .subscribe(settings => {
+        const providerSettings = settings?.metadataProviderSettings ?? {};
+        this.providers = Object.entries(providerSettings)
+          .filter(([_, value]) => !!value && typeof value === 'object' && 'enabled' in value && (value as any).enabled)
+          .map(([key]) => {
+            // Handle special cases for provider names that don't follow simple capitalization
+            const providerNameMap: {[key: string]: string} = {
+              'iTunes': 'iTunes',
+              'goodReads': 'GoodReads'
+            };
+            return providerNameMap[key] || key.charAt(0).toUpperCase() + key.slice(1);
+          });
+      });
+  }
 
   private initializeFieldOptions(): FieldOptions {
     return this.fields.reduce((acc, field) => {

--- a/booklore-ui/src/app/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.html
+++ b/booklore-ui/src/app/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.html
@@ -52,6 +52,23 @@
     <p-checkbox [(ngModel)]="googleEnabled" [binary]="true"></p-checkbox>
     <label class="font-medium">Google</label>
   </div>
+
+  <div class="flex flex-col gap-2">
+    <div class="flex items-center gap-4">
+      <p-checkbox [(ngModel)]="iTunesEnabled" [binary]="true"></p-checkbox>
+      <label class="font-medium">iTunes</label>
+    </div>
+
+    <div class="flex flex-col gap-2 pl-9 pt-1">
+      <label class="font-medium text-sm">Country</label>
+      <p-select
+        [options]="iTunesCountries"
+        [(ngModel)]="selectedITunesCountry"
+        placeholder="Select Country"
+        class="w-full max-w-52">
+      </p-select>
+    </div>
+  </div>
   
 
   <div class="flex flex-col gap-2">

--- a/booklore-ui/src/app/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.ts
+++ b/booklore-ui/src/app/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.ts
@@ -50,6 +50,24 @@ export class MetadataProviderSettingsComponent implements OnInit {
     {label: 'amazon.tr', value: 'tr'}
   ];
 
+  iTunesCountries = [
+    {label: 'United States', value: 'us'},
+    {label: 'United Kingdom', value: 'gb'},
+    {label: 'Canada', value: 'ca'},
+    {label: 'Australia', value: 'au'},
+    {label: 'Germany', value: 'de'},
+    {label: 'France', value: 'fr'},
+    {label: 'Italy', value: 'it'},
+    {label: 'Spain', value: 'es'},
+    {label: 'Netherlands', value: 'nl'},
+    {label: 'Japan', value: 'jp'},
+    {label: 'Brazil', value: 'br'},
+    {label: 'India', value: 'in'},
+    {label: 'Mexico', value: 'mx'},
+    {label: 'Sweden', value: 'se'},
+    {label: 'Poland', value: 'pl'}
+  ];
+
   selectedAmazonDomain = 'com';
 
   hardcoverToken: string = '';
@@ -60,6 +78,8 @@ export class MetadataProviderSettingsComponent implements OnInit {
   googleEnabled: boolean = false;
   comicvineEnabled: boolean = false;
   comicvineToken: string = '';
+  iTunesEnabled: boolean = false;
+  selectedITunesCountry: string = 'us';
 
   private appSettingsService = inject(AppSettingsService);
   private messageService = inject(MessageService);
@@ -83,6 +103,8 @@ export class MetadataProviderSettingsComponent implements OnInit {
         this.hardcoverEnabled = metadataProviderSettings?.hardcover?.enabled ?? false;
         this.comicvineEnabled = metadataProviderSettings?.comicvine?.enabled ?? false;
         this.comicvineToken = metadataProviderSettings?.comicvine?.apiKey ?? '';
+        this.iTunesEnabled = metadataProviderSettings?.iTunes?.enabled ?? false;
+        this.selectedITunesCountry = metadataProviderSettings?.iTunes?.country ?? 'us';
       });
   }
 
@@ -121,6 +143,11 @@ export class MetadataProviderSettingsComponent implements OnInit {
           hardcover: {
             enabled: this.hardcoverEnabled,
             apiKey: this.hardcoverToken.trim()
+          },
+          
+          iTunes: {
+            enabled: this.iTunesEnabled,
+            country: this.selectedITunesCountry
           }
         }
       }


### PR DESCRIPTION
Adaptation of Ben Dodson's [iTunes artwork Finder](https://github.com/bendodson/itunes-artwork-finder) for Booklore to use to source cover images. Also selectable metadata services from hardcoding to dynamic list of the ones that are enabled for improved usability. This is pretty vibe-coded so a thorough review and edits would be good.