### PR TITLE
Fix docker build tests

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+      issues: read
+      checks: write
       pull-requests: write
 
     steps:
@@ -48,10 +50,42 @@ jobs:
 
       # Run backend tests with testcontainers
       - name: Run Backend Tests
+        id: backend_tests
         working-directory: ./booklore-api
         run: |
           echo "Running backend tests with testcontainers..."
           ./gradlew test
+        continue-on-error: true
+
+      # Publish test results
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            booklore-api/build/test-results/**/*.xml
+          check_name: Backend Test Results
+          comment_title: Backend Test Results
+          report_individual_runs: true
+          report_suite_logs: 'any'
+
+      # Upload test reports as artifacts
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-reports
+          path: |
+            booklore-api/build/reports/tests/
+            booklore-api/build/test-results/
+          retention-days: 30
+
+      # Fail the workflow if tests failed
+      - name: Check Test Results
+        if: steps.backend_tests.outcome == 'failure'
+        run: |
+          echo "❌ Backend tests failed! Check the test results above."
+          exit 1
 
       - name: Get Latest Master Version
         id: get_version

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -167,8 +167,8 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=${{ env.image_tag }} \
-            --tag booklore/booklore:${{ env.image_tag }} \
-            --tag ghcr.io/booklore-app/booklore:${{ env.image_tag }} \
+            --tag ${{ secrets.DOCKER_USERNAME }}/booklore:${{ env.image_tag }} \
+            --tag ghcr.io/${{ github.actor }}/booklore:${{ env.image_tag }} \
             --push .
 
       - name: Push Latest Tag (Only for Master)
@@ -177,8 +177,8 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=${{ env.new_tag }} \
-            --tag booklore/booklore:latest \
-            --tag ghcr.io/booklore-app/booklore:latest \
+            --tag ${{ secrets.DOCKER_USERNAME }}/booklore:latest \
+            --tag ghcr.io/${{ github.actor }}/booklore:latest \
             --push .
 
       - name: Create Git Tag (Only for Master)
@@ -199,6 +199,7 @@ jobs:
 
       - name: Notify Discord of New Release
         if: github.ref == 'refs/heads/master'
+        continue-on-error: true
         shell: bash
         env:
           GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Set up Java for backend tests
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Run backend tests with testcontainers
+      - name: Run Backend Tests
+        working-directory: ./booklore-api
+        run: |
+          echo "Running backend tests with testcontainers..."
+          ./gradlew test
+
       - name: Get Latest Master Version
         id: get_version
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG APP_VERSION
 RUN apk add --no-cache yq && \
     yq eval '.app.version = strenv(APP_VERSION)' -i /springboot-app/src/main/resources/application.yaml
 
-RUN gradle clean build
+RUN gradle clean build -x test
 
 # Stage 3: Final image
 FROM eclipse-temurin:21-jre-alpine


### PR DESCRIPTION
Fix GitHub Actions failures after introducing [`Testcontainers`](https://testcontainers.com/)

After merging #868, #870, and #872, repository tests now use `Testcontainers`.
GitHub Actions started failing because the workflow runs docker build, which executes tests during the build step.
Running Docker-in-Docker is required for that pattern, but it is not recommended (and effectively unsupported) with `buildx`.

Solution:
- Run tests directly in the GitHub Actions job (outside docker build).
- Publish test results to GitHub Actions. Example run: https://github.com/werwolfby/BookLore/actions/runs/17283694647/job/49056789485

> [!WARNING]
>
> Replaced hard-coded Docker repository tags with values derived from `github.actor` and `DOCKER_USERNAME`.
> This enables testing the workflow in personal forks while preserving backward compatibility with the main repository.

```diff
docker buildx build \
    --platform linux/amd64,linux/arm64 \
    --build-arg APP_VERSION=${{ env.image_tag }} \
-    --tag booklore/booklore:${{ env.image_tag }} \
-    --tag ghcr.io/booklore-app/booklore:${{ env.image_tag }} \
+    --tag ${{ secrets.DOCKER_USERNAME }}/booklore:${{ env.image_tag }} \
+    --tag ghcr.io/${{ github.actor }}/booklore:${{ env.image_tag }} \
    --push .
```

Assumption: `DOCKER_USERNAME` is set to booklore in the main repository.

