### PR TITLE
Fix GHA: return original names for docker tags

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -167,8 +167,8 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=${{ env.image_tag }} \
-            --tag ${{ secrets.DOCKER_USERNAME }}/booklore:${{ env.image_tag }} \
-            --tag ghcr.io/${{ github.actor }}/booklore:${{ env.image_tag }} \
+            --tag booklore/booklore:${{ env.image_tag }} \
+            --tag ghcr.io/booklore-app/booklore:${{ env.image_tag }} \
             --push .
 
       - name: Push Latest Tag (Only for Master)
@@ -177,8 +177,8 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=${{ env.new_tag }} \
-            --tag ${{ secrets.DOCKER_USERNAME }}/booklore:latest \
-            --tag ghcr.io/${{ github.actor }}/booklore:latest \
+            --tag booklore/booklore:latest \
+            --tag ghcr.io/booklore-app/booklore:latest \
             --push .
 
       - name: Create Git Tag (Only for Master)


### PR DESCRIPTION
In #1005 I made an assumption that variables were right (which I specified in warning section).

But assumption was wrong. So I can't test this PR on my personal fork (which this names were intendent to solve).

Just revert names usage to original `booklore` and `booklore-app` values.

P.S. I will check the documentation, probably I could find something like organization name for `booklore-app` and GH registry. And `booklore` could be moved to variables.

@adityachandelgit any thoughts?

Anyway this PR should finally fix the GHA.