### PR TITLE
fix: add content-type header for koreader-sync

### DIFF
--- a/booklore-api/src/test/java/com/adityachandel/booklore/controller/KoreaderControllerTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/controller/KoreaderControllerTest.java
@@ -36,6 +36,7 @@ class KoreaderControllerTest {
         when(koreaderService.authorizeUser()).thenReturn(ResponseEntity.ok(expected));
         ResponseEntity<Map<String, String>> resp = controller.authorizeUser();
         assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals(MediaType.APPLICATION_JSON, resp.getHeaders().getContentType());
         assertEquals(expected, resp.getBody());
     }
 


### PR DESCRIPTION
Adds content-type header that prevented some koreader sync clients from syncing with booklore