### PR TITLE
fix: add content-type header for koreader-sync auth 

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/KoreaderController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/KoreaderController.java
@@ -22,7 +22,9 @@ public class KoreaderController {
 
     @GetMapping("/users/auth")
     public ResponseEntity<Map<String, String>> authorizeUser() {
-        return koreaderService.authorizeUser();
+        return koreaderService
+            .authorizeUser()
+            .contentType(MediaType.APPLICATION_JSON);
     }
 
     @PostMapping("/users/create")

--- a/booklore-api/src/test/java/com/adityachandel/booklore/controller/KoreaderControllerTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/controller/KoreaderControllerTest.java
@@ -36,6 +36,7 @@ class KoreaderControllerTest {
         when(koreaderService.authorizeUser()).thenReturn(ResponseEntity.ok(expected));
         ResponseEntity<Map<String, String>> resp = controller.authorizeUser();
         assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals(MediaType.APPLICATION_JSON, resp.getHeaders().getContentType());
         assertEquals(expected, resp.getBody());
     }
 


### PR DESCRIPTION
Add content-type header for koreader-sync server in auth method. Needed for some koreader clients (tested in readest iOS app).

fixes https://github.com/booklore-app/booklore/issues/998