### PR TITLE
feat: ComicInfo.xml support for CBZ files

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -1,58 +1,332 @@
 package com.adityachandel.booklore.service.metadata.extractor;
 
 import com.adityachandel.booklore.model.dto.BookMetadata;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.stereotype.Component;
-
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 @Slf4j
 @Component
 public class CbxMetadataExtractor implements FileMetadataExtractor {
 
-    @Override
-    public BookMetadata extractMetadata(File file) {
-        String baseName = FilenameUtils.getBaseName(file.getName());
-        return BookMetadata.builder()
-                .title(baseName)
-                .build();
+  @Override
+  public BookMetadata extractMetadata(File file) {
+    String baseName = FilenameUtils.getBaseName(file.getName());
+    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+      return BookMetadata.builder().title(baseName).build();
     }
 
-    @Override
-    public byte[] extractCover(File file) {
-        return generatePlaceholderCover(250, 350);
+    try (ZipFile zipFile = new ZipFile(file)) {
+      ZipEntry entry = findComicInfoEntry(zipFile);
+      if (entry == null) {
+        return BookMetadata.builder().title(baseName).build();
+      }
+
+      try (InputStream is = zipFile.getInputStream(entry)) {
+        Document document = buildSecureDocument(is);
+        return mapDocumentToMetadata(document, baseName);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to extract metadata from CBZ", e);
+      return BookMetadata.builder().title(baseName).build();
+    }
+  }
+
+  private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      String name = entry.getName();
+      if ("comicinfo.xml".equalsIgnoreCase(name)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  private Document buildSecureDocument(InputStream is) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setExpandEntityReferences(false);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    return builder.parse(is);
+  }
+
+  private BookMetadata mapDocumentToMetadata(
+    Document document,
+    String fallbackTitle
+  ) {
+    BookMetadata.BookMetadataBuilder builder = BookMetadata.builder();
+
+    String title = getTextContent(document, "Title");
+    builder.title(title == null || title.isBlank() ? fallbackTitle : title);
+
+    builder.description(
+      coalesce(
+        getTextContent(document, "Summary"),
+        getTextContent(document, "Description")
+      )
+    );
+    builder.publisher(getTextContent(document, "Publisher"));
+    builder.seriesName(getTextContent(document, "Series"));
+    builder.seriesNumber(parseFloat(getTextContent(document, "Number")));
+    builder.seriesTotal(parseInteger(getTextContent(document, "Count")));
+    builder.publishedDate(
+      parseDate(
+        getTextContent(document, "Year"),
+        getTextContent(document, "Month"),
+        getTextContent(document, "Day")
+      )
+    );
+    builder.pageCount(
+      parseInteger(
+        coalesce(
+          getTextContent(document, "PageCount"),
+          getTextContent(document, "Pages")
+        )
+      )
+    );
+    builder.language(getTextContent(document, "LanguageISO"));
+
+    Set<String> authors = new HashSet<>();
+    authors.addAll(splitValues(getTextContent(document, "Writer")));
+    authors.addAll(splitValues(getTextContent(document, "Penciller")));
+    authors.addAll(splitValues(getTextContent(document, "Inker")));
+    authors.addAll(splitValues(getTextContent(document, "Colorist")));
+    authors.addAll(splitValues(getTextContent(document, "Letterer")));
+    authors.addAll(splitValues(getTextContent(document, "CoverArtist")));
+    if (!authors.isEmpty()) {
+      builder.authors(authors);
     }
 
-    private byte[] generatePlaceholderCover(int width, int height) {
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = image.createGraphics();
+    Set<String> categories = new HashSet<>();
+    categories.addAll(splitValues(getTextContent(document, "Genre")));
+    categories.addAll(splitValues(getTextContent(document, "Tags")));
+    if (!categories.isEmpty()) {
+      builder.categories(categories);
+    }
 
-        g.setColor(Color.LIGHT_GRAY);
-        g.fillRect(0, 0, width, height);
+    return builder.build();
+  }
 
-        g.setColor(Color.DARK_GRAY);
-        g.setFont(new Font("SansSerif", Font.BOLD, width / 10));
-        FontMetrics fm = g.getFontMetrics();
-        String text = "Preview Unavailable";
+  private String getTextContent(Document document, String tag) {
+    NodeList nodes = document.getElementsByTagName(tag);
+    if (nodes.getLength() == 0) {
+      return null;
+    }
+    return nodes.item(0).getTextContent().trim();
+  }
 
-        int textWidth = fm.stringWidth(text);
-        int textHeight = fm.getAscent();
-        g.drawString(text, (width - textWidth) / 2, (height + textHeight) / 2);
+  private String coalesce(String a, String b) {
+    return (a != null && !a.isBlank())
+      ? a
+      : (b != null && !b.isBlank() ? b : null);
+  }
 
-        g.dispose();
+  private Set<String> splitValues(String value) {
+    if (value == null) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(value.split("[,;]"))
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .collect(HashSet::new, Set::add, Set::addAll);
+  }
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            ImageIO.write(image, "jpg", baos);
-            return baos.toByteArray();
-        } catch (IOException e) {
-            log.warn("Failed to generate placeholder image", e);
-            return null;
+  private Integer parseInteger(String value) {
+    try {
+      return (value == null || value.isBlank())
+        ? null
+        : Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private Float parseFloat(String value) {
+    try {
+      return (value == null || value.isBlank())
+        ? null
+        : Float.parseFloat(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private LocalDate parseDate(String year, String month, String day) {
+    Integer y = parseInteger(year);
+    Integer m = parseInteger(month);
+    Integer d = parseInteger(day);
+    if (y == null) {
+      return null;
+    }
+    if (m == null) {
+      m = 1;
+    }
+    if (d == null) {
+      d = 1;
+    }
+    try {
+      return LocalDate.of(y, m, d);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Override
+  public byte[] extractCover(File file) {
+    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+      return generatePlaceholderCover(250, 350);
+    }
+
+    try (ZipFile zipFile = new ZipFile(file)) {
+      ZipEntry coverEntry = findFrontCoverEntry(zipFile);
+      if (coverEntry != null) {
+        try (InputStream is = zipFile.getInputStream(coverEntry)) {
+          return is.readAllBytes();
         }
+      }
+    } catch (Exception e) {
+      log.warn("Failed to extract cover image from CBZ", e);
     }
+
+    return generatePlaceholderCover(250, 350);
+  }
+
+  private ZipEntry findFrontCoverEntry(ZipFile zipFile) {
+    ZipEntry comicInfoEntry = findComicInfoEntry(zipFile);
+    if (comicInfoEntry != null) {
+      try (InputStream is = zipFile.getInputStream(comicInfoEntry)) {
+        Document document = buildSecureDocument(is);
+        String imageName = findFrontCoverImageName(document);
+        if (imageName != null) {
+          ZipEntry byName = zipFile.getEntry(imageName);
+          if (byName != null) {
+            return byName;
+          }
+          try {
+            int index = Integer.parseInt(imageName);
+            ZipEntry byIndex = findImageEntryByIndex(zipFile, index);
+            if (byIndex != null) {
+              return byIndex;
+            }
+          } catch (NumberFormatException ignore) {
+            // ignore
+          }
+        }
+      } catch (Exception e) {
+        log.warn("Failed to parse ComicInfo.xml for cover", e);
+      }
+    }
+
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      if (!entry.isDirectory() && isImageEntry(entry.getName())) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  private ZipEntry findImageEntryByIndex(ZipFile zipFile, int index) {
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    int count = 0;
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      if (!entry.isDirectory() && isImageEntry(entry.getName())) {
+        if (count == index) {
+          return entry;
+        }
+        count++;
+      }
+    }
+    return null;
+  }
+
+  private String findFrontCoverImageName(Document document) {
+    NodeList pages = document.getElementsByTagName("Page");
+    for (int i = 0; i < pages.getLength(); i++) {
+      org.w3c.dom.Node node = pages.item(i);
+      if (node instanceof org.w3c.dom.Element) {
+        org.w3c.dom.Element page = (org.w3c.dom.Element) node;
+        String type = page.getAttribute("Type");
+        if (type != null && type.equalsIgnoreCase("FrontCover")) {
+          String imageFile = page.getAttribute("ImageFile");
+          if (imageFile != null && !imageFile.isBlank()) {
+            return imageFile.trim();
+          }
+          String image = page.getAttribute("Image");
+          if (image != null && !image.isBlank()) {
+            return image.trim();
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean isImageEntry(String name) {
+    String lower = name.toLowerCase();
+    return (
+      lower.endsWith(".jpg") ||
+      lower.endsWith(".jpeg") ||
+      lower.endsWith(".png") ||
+      lower.endsWith(".gif") ||
+      lower.endsWith(".bmp") ||
+      lower.endsWith(".webp")
+    );
+  }
+
+  private byte[] generatePlaceholderCover(int width, int height) {
+    BufferedImage image = new BufferedImage(
+      width,
+      height,
+      BufferedImage.TYPE_INT_RGB
+    );
+    Graphics2D g = image.createGraphics();
+
+    g.setColor(Color.LIGHT_GRAY);
+    g.fillRect(0, 0, width, height);
+
+    g.setColor(Color.DARK_GRAY);
+    g.setFont(new Font("SansSerif", Font.BOLD, width / 10));
+    FontMetrics fm = g.getFontMetrics();
+    String text = "Preview Unavailable";
+
+    int textWidth = fm.stringWidth(text);
+    int textHeight = fm.getAscent();
+    g.drawString(text, (width - textWidth) / 2, (height + textHeight) / 2);
+
+    g.dispose();
+
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      ImageIO.write(image, "jpg", baos);
+      return baos.toByteArray();
+    } catch (IOException e) {
+      log.warn("Failed to generate placeholder image", e);
+      return null;
+    }
+  }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -1,0 +1,181 @@
+package com.adityachandel.booklore.service.metadata.writer;
+
+import com.adityachandel.booklore.model.MetadataClearFlags;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.BookFileType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+@Slf4j
+@Component
+public class CbxMetadataWriter implements MetadataWriter {
+
+    @Override
+    public void writeMetadataToFile(File file, BookMetadataEntity metadata, String thumbnailUrl, boolean restoreMode, MetadataClearFlags clearFlags) {
+        try {
+            Path temp = Files.createTempFile("cbx_edit", ".cbz");
+            try (ZipFile zipFile = new ZipFile(file);
+                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(temp))) {
+
+                ZipEntry existing = findComicInfoEntry(zipFile);
+                Document doc;
+                if (existing != null) {
+                    try (InputStream is = zipFile.getInputStream(existing)) {
+                        doc = buildSecureDocument(is);
+                    }
+                } else {
+                    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                    DocumentBuilder builder = factory.newDocumentBuilder();
+                    doc = builder.newDocument();
+                    doc.appendChild(doc.createElement("ComicInfo"));
+                }
+                Element root = doc.getDocumentElement();
+                MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
+
+                helper.copyTitle(restoreMode, clearFlags != null && clearFlags.isTitle(), val -> setElement(doc, root, "Title", val));
+                helper.copyDescription(restoreMode, clearFlags != null && clearFlags.isDescription(), val -> {
+                    setElement(doc, root, "Summary", val);
+                    removeElement(root, "Description");
+                });
+                helper.copyPublisher(restoreMode, clearFlags != null && clearFlags.isPublisher(), val -> setElement(doc, root, "Publisher", val));
+                helper.copySeriesName(restoreMode, clearFlags != null && clearFlags.isSeriesName(), val -> setElement(doc, root, "Series", val));
+                helper.copySeriesNumber(restoreMode, clearFlags != null && clearFlags.isSeriesNumber(), val -> setElement(doc, root, "Number", formatFloat(val)));
+                helper.copySeriesTotal(restoreMode, clearFlags != null && clearFlags.isSeriesTotal(), val -> setElement(doc, root, "Count", val != null ? val.toString() : null));
+                helper.copyPublishedDate(restoreMode, clearFlags != null && clearFlags.isPublishedDate(), date -> setDateElements(doc, root, date));
+                helper.copyPageCount(restoreMode, clearFlags != null && clearFlags.isPageCount(), val -> setElement(doc, root, "PageCount", val != null ? val.toString() : null));
+                helper.copyLanguage(restoreMode, clearFlags != null && clearFlags.isLanguage(), val -> setElement(doc, root, "LanguageISO", val));
+                helper.copyAuthors(restoreMode, clearFlags != null && clearFlags.isAuthors(), set -> {
+                    setElement(doc, root, "Writer", join(set));
+                    removeElement(root, "Penciller");
+                    removeElement(root, "Inker");
+                    removeElement(root, "Colorist");
+                    removeElement(root, "Letterer");
+                    removeElement(root, "CoverArtist");
+                });
+                helper.copyCategories(restoreMode, clearFlags != null && clearFlags.isCategories(), set -> {
+                    setElement(doc, root, "Genre", join(set));
+                    removeElement(root, "Tags");
+                });
+
+                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                transformer.transform(new DOMSource(doc), new StreamResult(baos));
+                byte[] xmlBytes = baos.toByteArray();
+
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    if (existing != null && entry.getName().equals(existing.getName())) {
+                        continue;
+                    }
+                    zos.putNextEntry(new ZipEntry(entry.getName()));
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        is.transferTo(zos);
+                    }
+                    zos.closeEntry();
+                }
+
+                String entryName = existing != null ? existing.getName() : "ComicInfo.xml";
+                zos.putNextEntry(new ZipEntry(entryName));
+                zos.write(xmlBytes);
+                zos.closeEntry();
+            }
+            Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            log.warn("Failed to write metadata to CBZ file {}: {}", file.getName(), e.getMessage(), e);
+        }
+    }
+
+    private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            if ("comicinfo.xml".equalsIgnoreCase(entry.getName())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Document buildSecureDocument(InputStream is) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setExpandEntityReferences(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(is);
+    }
+
+    private void setElement(Document doc, Element root, String tag, String value) {
+        removeElement(root, tag);
+        if (value != null && !value.isBlank()) {
+            Element el = doc.createElement(tag);
+            el.setTextContent(value);
+            root.appendChild(el);
+        }
+    }
+
+    private void removeElement(Element root, String tag) {
+        NodeList nodes = root.getElementsByTagName(tag);
+        for (int i = nodes.getLength() - 1; i >= 0; i--) {
+            root.removeChild(nodes.item(i));
+        }
+    }
+
+    private void setDateElements(Document doc, Element root, LocalDate date) {
+        if (date == null) {
+            removeElement(root, "Year");
+            removeElement(root, "Month");
+            removeElement(root, "Day");
+            return;
+        }
+        setElement(doc, root, "Year", Integer.toString(date.getYear()));
+        setElement(doc, root, "Month", Integer.toString(date.getMonthValue()));
+        setElement(doc, root, "Day", Integer.toString(date.getDayOfMonth()));
+    }
+
+    private String join(Set<String> set) {
+        return (set == null || set.isEmpty()) ? null : String.join(", ", set);
+    }
+
+    private String formatFloat(Float val) {
+        if (val == null) return null;
+        if (val % 1 == 0) return Integer.toString(val.intValue());
+        return String.format(java.util.Locale.US, "%s", val);
+    }
+
+    @Override
+    public BookFileType getSupportedBookType() {
+        return BookFileType.CBX;
+    }
+}


### PR DESCRIPTION
Adds `ComicInfo.xml` metadata file support for .CBZ files. 

- Bookdrop process: reads the metadata from ComicInfo.xml file when adding new CBZ comic files
- Writes metadata edits back to ComicInfo.xml file, matching existing .EPUB _"Write to File"_ support

Open Issues:
- #861 

Additional details:
- `comicinfo.xml` schema: [https://github.com/anansi-project/comicinfo/tree/main/schema](https://github.com/anansi-project/comicinfo/tree/main/schema)