### PR TITLE
feat: ComicInfo.xml support for CBX files

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
@@ -114,7 +114,25 @@ public class BookMetadataUpdater {
 
                     File file = new File(bookEntity.getFullFilePath().toUri());
                     writer.writeMetadataToFile(file, metadata, thumbnailUrl, false, clearFlags);
-                    String newHash = FileFingerprint.generateHash(bookEntity.getFullFilePath());
+                    
+                    String newHash = "";
+
+                    // Special handling: If original file was .cbr and now .cbz exists, update to .cbz
+                    File resultingFile = file;
+                    if (!file.exists()) {
+                        String cbzName = file.getName().replaceFirst("(?i)\\.cbr$", ".cbz");
+                        File cbzFile = new File(file.getParentFile(), cbzName);
+                        if (cbzFile.exists()) {
+                            bookEntity.setFileName(cbzName);
+                            resultingFile = cbzFile;
+                        }
+                        bookEntity.setFileSizeKb(resultingFile.length() / 1024);
+                        log.info("!!! Converted CBR → CBZ: {} -> {}", file.getAbsolutePath(), resultingFile.getAbsolutePath());
+                        newHash = FileFingerprint.generateHash(resultingFile.toPath());
+                    } else {
+                        newHash = FileFingerprint.generateHash(bookEntity.getFullFilePath());
+                    }
+                    
                     bookEntity.setCurrentHash(newHash);
                     log.info("Metadata written for book ID {}", bookId);
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -1,8 +1,11 @@
 package com.adityachandel.booklore.service.metadata.extractor;
 
 import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.github.junrar.Archive;
+import com.github.junrar.rarfile.FileHeader;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -14,6 +17,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
 import javax.imageio.ImageIO;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -31,23 +38,51 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
   @Override
   public BookMetadata extractMetadata(File file) {
     String baseName = FilenameUtils.getBaseName(file.getName());
-    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+    String lowerName = file.getName().toLowerCase();
+
+    // Non-archive (fallback)
+    if (!lowerName.endsWith(".cbz") && !lowerName.endsWith(".cbr")) {
       return BookMetadata.builder().title(baseName).build();
     }
 
-    try (ZipFile zipFile = new ZipFile(file)) {
-      ZipEntry entry = findComicInfoEntry(zipFile);
-      if (entry == null) {
+    // CBZ path (ZIP)
+    if (lowerName.endsWith(".cbz")) {
+      try (ZipFile zipFile = new ZipFile(file)) {
+        ZipEntry entry = findComicInfoEntry(zipFile);
+        if (entry == null) {
+          return BookMetadata.builder().title(baseName).build();
+        }
+        try (InputStream is = zipFile.getInputStream(entry)) {
+          Document document = buildSecureDocument(is);
+          return mapDocumentToMetadata(document, baseName);
+        }
+      } catch (Exception e) {
+        log.warn("Failed to extract metadata from CBZ", e);
         return BookMetadata.builder().title(baseName).build();
       }
+    }
 
-      try (InputStream is = zipFile.getInputStream(entry)) {
+    // CBR path (RAR)
+    Archive archive = null;
+    try {
+      archive = new Archive(file);
+      FileHeader header = findComicInfoHeader(archive);
+      if (header == null) {
+        return BookMetadata.builder().title(baseName).build();
+      }
+      byte[] xmlBytes = readRarEntryBytes(archive, header);
+      if (xmlBytes == null) {
+        return BookMetadata.builder().title(baseName).build();
+      }
+      try (InputStream is = new ByteArrayInputStream(xmlBytes)) {
         Document document = buildSecureDocument(is);
         return mapDocumentToMetadata(document, baseName);
       }
     } catch (Exception e) {
-      log.warn("Failed to extract metadata from CBZ", e);
+      log.warn("Failed to extract metadata from CBR", e);
       return BookMetadata.builder().title(baseName).build();
+      } finally {
+      try { if (archive != null) archive.close(); } catch (Exception ignore) {}
     }
   }
 
@@ -196,19 +231,78 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
 
   @Override
   public byte[] extractCover(File file) {
-    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+    String lowerName = file.getName().toLowerCase();
+
+    // Non-archive fallback
+    if (!lowerName.endsWith(".cbz") && !lowerName.endsWith(".cbr")) {
       return generatePlaceholderCover(250, 350);
     }
 
-    try (ZipFile zipFile = new ZipFile(file)) {
-      ZipEntry coverEntry = findFrontCoverEntry(zipFile);
-      if (coverEntry != null) {
-        try (InputStream is = zipFile.getInputStream(coverEntry)) {
-          return is.readAllBytes();
+    // CBZ path
+    if (lowerName.endsWith(".cbz")) {
+      try (ZipFile zipFile = new ZipFile(file)) {
+        ZipEntry coverEntry = findFrontCoverEntry(zipFile);
+        if (coverEntry != null) {
+          try (InputStream is = zipFile.getInputStream(coverEntry)) {
+            return is.readAllBytes();
+          }
+        } else {
+          // Fallback: first image after sorting alphabetically
+          ZipEntry firstImage = findFirstAlphabeticalImageEntry(zipFile);
+          if (firstImage != null) {
+            try (InputStream is2 = zipFile.getInputStream(firstImage)) {
+              return is2.readAllBytes();
+            }
+          }
+        }
+      } catch (Exception e) {
+        log.warn("Failed to extract cover image from CBZ", e);
+        return generatePlaceholderCover(250, 350);
+      }
+    }
+
+    // CBR path
+    Archive archive = null;
+    try {
+      archive = new Archive(file);
+
+      // Try via ComicInfo.xml first
+      FileHeader comicInfo = findComicInfoHeader(archive);
+      if (comicInfo != null) {
+        byte[] xmlBytes = readRarEntryBytes(archive, comicInfo);
+        if (xmlBytes != null) {
+          try (InputStream is = new ByteArrayInputStream(xmlBytes)) {
+            Document document = buildSecureDocument(is);
+            String imageName = findFrontCoverImageName(document);
+            if (imageName != null) {
+              FileHeader byName = findRarHeaderByName(archive, imageName);
+              if (byName != null) {
+                return readRarEntryBytes(archive, byName);
+              }
+              try {
+                int index = Integer.parseInt(imageName);
+                FileHeader byIndex = findRarImageHeaderByIndex(archive, index);
+                if (byIndex != null) {
+                  return readRarEntryBytes(archive, byIndex);
+                }
+              } catch (NumberFormatException ignore) {
+                // ignore and continue fallback
+              }
+            }
+          }
         }
       }
+
+      // Fallback: first image in alphabetical order
+      FileHeader firstImage = findFirstAlphabeticalImageHeader(archive);
+      if (firstImage != null) {
+        return readRarEntryBytes(archive, firstImage);
+      }
     } catch (Exception e) {
-      log.warn("Failed to extract cover image from CBZ", e);
+      log.warn("Failed to extract cover image from CBR", e);
+      return generatePlaceholderCover(250, 350);
+    } finally {
+      try { if (archive != null) archive.close(); } catch (Exception ignore) {}
     }
 
     return generatePlaceholderCover(250, 350);
@@ -239,15 +333,8 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
         log.warn("Failed to parse ComicInfo.xml for cover", e);
       }
     }
-
-    Enumeration<? extends ZipEntry> entries = zipFile.entries();
-    while (entries.hasMoreElements()) {
-      ZipEntry entry = entries.nextElement();
-      if (!entry.isDirectory() && isImageEntry(entry.getName())) {
-        return entry;
-      }
-    }
-    return null;
+    ZipEntry firstImage = findFirstAlphabeticalImageEntry(zipFile);
+    return firstImage;
   }
 
   private ZipEntry findImageEntryByIndex(ZipFile zipFile, int index) {
@@ -329,4 +416,112 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
       return null;
     }
   }
+
+
+  // ==== RAR (.cbr) helpers ====
+  private FileHeader findComicInfoHeader(Archive archive) {
+    if (archive == null) return null;
+    for (FileHeader fh : archive.getFileHeaders()) {
+      String name = fh.getFileName();
+      if (name == null) continue;
+      String base = baseName(name);
+      if ("comicinfo.xml".equalsIgnoreCase(base)) {
+        return fh;
+      }
+    }
+    return null;
+  }
+
+  private FileHeader findRarHeaderByName(Archive archive, String imageName) {
+    if (archive == null || imageName == null) return null;
+    for (FileHeader fh : archive.getFileHeaders()) {
+      String name = fh.getFileName();
+      if (name == null) continue;
+      if (name.equalsIgnoreCase(imageName)) return fh;
+      // also try base-name match to be lenient
+      if (baseName(name).equalsIgnoreCase(baseName(imageName))) return fh;
+    }
+    return null;
+  }
+
+  private FileHeader findRarImageHeaderByIndex(Archive archive, int index) {
+    int count = 0;
+    for (FileHeader fh : archive.getFileHeaders()) {
+      if (!fh.isDirectory() && isImageEntry(fh.getFileName())) {
+        if (count == index) return fh;
+        count++;
+      }
+    }
+    return null;
+  }
+
+  private FileHeader findFirstImageHeader(Archive archive) {
+    for (FileHeader fh : archive.getFileHeaders()) {
+      if (!fh.isDirectory() && isImageEntry(fh.getFileName())) {
+        return fh;
+      }
+    }
+    return null;
+  }
+
+  private byte[] readRarEntryBytes(Archive archive, FileHeader header) {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      archive.extractFile(header, baos);
+      return baos.toByteArray();
+    } catch (Exception e) {
+      log.warn("Failed to read RAR entry bytes for {}", header != null ? header.getFileName() : "<null>", e);
+      return null;
+    }
+  }
+
+  private String baseName(String path) {
+    if (path == null) return null;
+    int slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+    return slash >= 0 ? path.substring(slash + 1) : path;
+  }  
+
+  private FileHeader findFirstAlphabeticalImageHeader(Archive archive) {
+    if (archive == null) return null;
+    List<FileHeader> images = new ArrayList<>();
+    for (FileHeader fh : archive.getFileHeaders()) {
+      if (fh == null || fh.isDirectory()) continue;
+      String name = fh.getFileName();
+      if (name == null) continue;
+      if (isImageEntry(name)) {
+        images.add(fh);
+      }
+    }
+    if (images.isEmpty()) return null;
+    Collections.sort(images, new Comparator<FileHeader>() {
+      @Override
+      public int compare(FileHeader a, FileHeader b) {
+        String na = a.getFileName() == null ? "" : a.getFileName();
+        String nb = b.getFileName() == null ? "" : b.getFileName();
+        return na.compareToIgnoreCase(nb);
+      }
+    });
+    return images.get(0);
+  }
+
+  private ZipEntry findFirstAlphabeticalImageEntry(ZipFile zipFile) {
+    List<ZipEntry> images = new ArrayList<>();
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry e = entries.nextElement();
+      if (!e.isDirectory() && isImageEntry(e.getName())) {
+        images.add(e);
+      }
+    }
+    if (images.isEmpty()) return null;
+    images.sort(new Comparator<ZipEntry>() {
+      @Override
+      public int compare(ZipEntry a, ZipEntry b) {
+        String na = a.getName() == null ? "" : a.getName();
+        String nb = b.getName() == null ? "" : b.getName();
+        return na.compareToIgnoreCase(nb);
+      }
+    });
+    return images.get(0);
+  }
+  
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -1,58 +1,332 @@
 package com.adityachandel.booklore.service.metadata.extractor;
 
 import com.adityachandel.booklore.model.dto.BookMetadata;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.stereotype.Component;
-
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 @Slf4j
 @Component
 public class CbxMetadataExtractor implements FileMetadataExtractor {
 
-    @Override
-    public BookMetadata extractMetadata(File file) {
-        String baseName = FilenameUtils.getBaseName(file.getName());
-        return BookMetadata.builder()
-                .title(baseName)
-                .build();
+  @Override
+  public BookMetadata extractMetadata(File file) {
+    String baseName = FilenameUtils.getBaseName(file.getName());
+    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+      return BookMetadata.builder().title(baseName).build();
     }
 
-    @Override
-    public byte[] extractCover(File file) {
-        return generatePlaceholderCover(250, 350);
+    try (ZipFile zipFile = new ZipFile(file)) {
+      ZipEntry entry = findComicInfoEntry(zipFile);
+      if (entry == null) {
+        return BookMetadata.builder().title(baseName).build();
+      }
+
+      try (InputStream is = zipFile.getInputStream(entry)) {
+        Document document = buildSecureDocument(is);
+        return mapDocumentToMetadata(document, baseName);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to extract metadata from CBZ", e);
+      return BookMetadata.builder().title(baseName).build();
+    }
+  }
+
+  private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      String name = entry.getName();
+      if ("comicinfo.xml".equalsIgnoreCase(name)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  private Document buildSecureDocument(InputStream is) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setExpandEntityReferences(false);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    return builder.parse(is);
+  }
+
+  private BookMetadata mapDocumentToMetadata(
+    Document document,
+    String fallbackTitle
+  ) {
+    BookMetadata.BookMetadataBuilder builder = BookMetadata.builder();
+
+    String title = getTextContent(document, "Title");
+    builder.title(title == null || title.isBlank() ? fallbackTitle : title);
+
+    builder.description(
+      coalesce(
+        getTextContent(document, "Summary"),
+        getTextContent(document, "Description")
+      )
+    );
+    builder.publisher(getTextContent(document, "Publisher"));
+    builder.seriesName(getTextContent(document, "Series"));
+    builder.seriesNumber(parseFloat(getTextContent(document, "Number")));
+    builder.seriesTotal(parseInteger(getTextContent(document, "Count")));
+    builder.publishedDate(
+      parseDate(
+        getTextContent(document, "Year"),
+        getTextContent(document, "Month"),
+        getTextContent(document, "Day")
+      )
+    );
+    builder.pageCount(
+      parseInteger(
+        coalesce(
+          getTextContent(document, "PageCount"),
+          getTextContent(document, "Pages")
+        )
+      )
+    );
+    builder.language(getTextContent(document, "LanguageISO"));
+
+    Set<String> authors = new HashSet<>();
+    authors.addAll(splitValues(getTextContent(document, "Writer")));
+    authors.addAll(splitValues(getTextContent(document, "Penciller")));
+    authors.addAll(splitValues(getTextContent(document, "Inker")));
+    authors.addAll(splitValues(getTextContent(document, "Colorist")));
+    authors.addAll(splitValues(getTextContent(document, "Letterer")));
+    authors.addAll(splitValues(getTextContent(document, "CoverArtist")));
+    if (!authors.isEmpty()) {
+      builder.authors(authors);
     }
 
-    private byte[] generatePlaceholderCover(int width, int height) {
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = image.createGraphics();
+    Set<String> categories = new HashSet<>();
+    categories.addAll(splitValues(getTextContent(document, "Genre")));
+    categories.addAll(splitValues(getTextContent(document, "Tags")));
+    if (!categories.isEmpty()) {
+      builder.categories(categories);
+    }
 
-        g.setColor(Color.LIGHT_GRAY);
-        g.fillRect(0, 0, width, height);
+    return builder.build();
+  }
 
-        g.setColor(Color.DARK_GRAY);
-        g.setFont(new Font("SansSerif", Font.BOLD, width / 10));
-        FontMetrics fm = g.getFontMetrics();
-        String text = "Preview Unavailable";
+  private String getTextContent(Document document, String tag) {
+    NodeList nodes = document.getElementsByTagName(tag);
+    if (nodes.getLength() == 0) {
+      return null;
+    }
+    return nodes.item(0).getTextContent().trim();
+  }
 
-        int textWidth = fm.stringWidth(text);
-        int textHeight = fm.getAscent();
-        g.drawString(text, (width - textWidth) / 2, (height + textHeight) / 2);
+  private String coalesce(String a, String b) {
+    return (a != null && !a.isBlank())
+      ? a
+      : (b != null && !b.isBlank() ? b : null);
+  }
 
-        g.dispose();
+  private Set<String> splitValues(String value) {
+    if (value == null) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(value.split("[,;]"))
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .collect(HashSet::new, Set::add, Set::addAll);
+  }
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            ImageIO.write(image, "jpg", baos);
-            return baos.toByteArray();
-        } catch (IOException e) {
-            log.warn("Failed to generate placeholder image", e);
-            return null;
+  private Integer parseInteger(String value) {
+    try {
+      return (value == null || value.isBlank())
+        ? null
+        : Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private Float parseFloat(String value) {
+    try {
+      return (value == null || value.isBlank())
+        ? null
+        : Float.parseFloat(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private LocalDate parseDate(String year, String month, String day) {
+    Integer y = parseInteger(year);
+    Integer m = parseInteger(month);
+    Integer d = parseInteger(day);
+    if (y == null) {
+      return null;
+    }
+    if (m == null) {
+      m = 1;
+    }
+    if (d == null) {
+      d = 1;
+    }
+    try {
+      return LocalDate.of(y, m, d);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Override
+  public byte[] extractCover(File file) {
+    if (!file.getName().toLowerCase().endsWith(".cbz")) {
+      return generatePlaceholderCover(250, 350);
+    }
+
+    try (ZipFile zipFile = new ZipFile(file)) {
+      ZipEntry coverEntry = findFrontCoverEntry(zipFile);
+      if (coverEntry != null) {
+        try (InputStream is = zipFile.getInputStream(coverEntry)) {
+          return is.readAllBytes();
         }
+      }
+    } catch (Exception e) {
+      log.warn("Failed to extract cover image from CBZ", e);
     }
+
+    return generatePlaceholderCover(250, 350);
+  }
+
+  private ZipEntry findFrontCoverEntry(ZipFile zipFile) {
+    ZipEntry comicInfoEntry = findComicInfoEntry(zipFile);
+    if (comicInfoEntry != null) {
+      try (InputStream is = zipFile.getInputStream(comicInfoEntry)) {
+        Document document = buildSecureDocument(is);
+        String imageName = findFrontCoverImageName(document);
+        if (imageName != null) {
+          ZipEntry byName = zipFile.getEntry(imageName);
+          if (byName != null) {
+            return byName;
+          }
+          try {
+            int index = Integer.parseInt(imageName);
+            ZipEntry byIndex = findImageEntryByIndex(zipFile, index);
+            if (byIndex != null) {
+              return byIndex;
+            }
+          } catch (NumberFormatException ignore) {
+            // ignore
+          }
+        }
+      } catch (Exception e) {
+        log.warn("Failed to parse ComicInfo.xml for cover", e);
+      }
+    }
+
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      if (!entry.isDirectory() && isImageEntry(entry.getName())) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  private ZipEntry findImageEntryByIndex(ZipFile zipFile, int index) {
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    int count = 0;
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      if (!entry.isDirectory() && isImageEntry(entry.getName())) {
+        if (count == index) {
+          return entry;
+        }
+        count++;
+      }
+    }
+    return null;
+  }
+
+  private String findFrontCoverImageName(Document document) {
+    NodeList pages = document.getElementsByTagName("Page");
+    for (int i = 0; i < pages.getLength(); i++) {
+      org.w3c.dom.Node node = pages.item(i);
+      if (node instanceof org.w3c.dom.Element) {
+        org.w3c.dom.Element page = (org.w3c.dom.Element) node;
+        String type = page.getAttribute("Type");
+        if (type != null && type.equalsIgnoreCase("FrontCover")) {
+          String imageFile = page.getAttribute("ImageFile");
+          if (imageFile != null && !imageFile.isBlank()) {
+            return imageFile.trim();
+          }
+          String image = page.getAttribute("Image");
+          if (image != null && !image.isBlank()) {
+            return image.trim();
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean isImageEntry(String name) {
+    String lower = name.toLowerCase();
+    return (
+      lower.endsWith(".jpg") ||
+      lower.endsWith(".jpeg") ||
+      lower.endsWith(".png") ||
+      lower.endsWith(".gif") ||
+      lower.endsWith(".bmp") ||
+      lower.endsWith(".webp")
+    );
+  }
+
+  private byte[] generatePlaceholderCover(int width, int height) {
+    BufferedImage image = new BufferedImage(
+      width,
+      height,
+      BufferedImage.TYPE_INT_RGB
+    );
+    Graphics2D g = image.createGraphics();
+
+    g.setColor(Color.LIGHT_GRAY);
+    g.fillRect(0, 0, width, height);
+
+    g.setColor(Color.DARK_GRAY);
+    g.setFont(new Font("SansSerif", Font.BOLD, width / 10));
+    FontMetrics fm = g.getFontMetrics();
+    String text = "Preview Unavailable";
+
+    int textWidth = fm.stringWidth(text);
+    int textHeight = fm.getAscent();
+    g.drawString(text, (width - textWidth) / 2, (height + textHeight) / 2);
+
+    g.dispose();
+
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      ImageIO.write(image, "jpg", baos);
+      return baos.toByteArray();
+    } catch (IOException e) {
+      log.warn("Failed to generate placeholder image", e);
+      return null;
+    }
+  }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -1,0 +1,181 @@
+package com.adityachandel.booklore.service.metadata.writer;
+
+import com.adityachandel.booklore.model.MetadataClearFlags;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.BookFileType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+@Slf4j
+@Component
+public class CbxMetadataWriter implements MetadataWriter {
+
+    @Override
+    public void writeMetadataToFile(File file, BookMetadataEntity metadata, String thumbnailUrl, boolean restoreMode, MetadataClearFlags clearFlags) {
+        try {
+            Path temp = Files.createTempFile("cbx_edit", ".cbz");
+            try (ZipFile zipFile = new ZipFile(file);
+                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(temp))) {
+
+                ZipEntry existing = findComicInfoEntry(zipFile);
+                Document doc;
+                if (existing != null) {
+                    try (InputStream is = zipFile.getInputStream(existing)) {
+                        doc = buildSecureDocument(is);
+                    }
+                } else {
+                    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                    DocumentBuilder builder = factory.newDocumentBuilder();
+                    doc = builder.newDocument();
+                    doc.appendChild(doc.createElement("ComicInfo"));
+                }
+                Element root = doc.getDocumentElement();
+                MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
+
+                helper.copyTitle(restoreMode, clearFlags != null && clearFlags.isTitle(), val -> setElement(doc, root, "Title", val));
+                helper.copyDescription(restoreMode, clearFlags != null && clearFlags.isDescription(), val -> {
+                    setElement(doc, root, "Summary", val);
+                    removeElement(root, "Description");
+                });
+                helper.copyPublisher(restoreMode, clearFlags != null && clearFlags.isPublisher(), val -> setElement(doc, root, "Publisher", val));
+                helper.copySeriesName(restoreMode, clearFlags != null && clearFlags.isSeriesName(), val -> setElement(doc, root, "Series", val));
+                helper.copySeriesNumber(restoreMode, clearFlags != null && clearFlags.isSeriesNumber(), val -> setElement(doc, root, "Number", formatFloat(val)));
+                helper.copySeriesTotal(restoreMode, clearFlags != null && clearFlags.isSeriesTotal(), val -> setElement(doc, root, "Count", val != null ? val.toString() : null));
+                helper.copyPublishedDate(restoreMode, clearFlags != null && clearFlags.isPublishedDate(), date -> setDateElements(doc, root, date));
+                helper.copyPageCount(restoreMode, clearFlags != null && clearFlags.isPageCount(), val -> setElement(doc, root, "PageCount", val != null ? val.toString() : null));
+                helper.copyLanguage(restoreMode, clearFlags != null && clearFlags.isLanguage(), val -> setElement(doc, root, "LanguageISO", val));
+                helper.copyAuthors(restoreMode, clearFlags != null && clearFlags.isAuthors(), set -> {
+                    setElement(doc, root, "Writer", join(set));
+                    removeElement(root, "Penciller");
+                    removeElement(root, "Inker");
+                    removeElement(root, "Colorist");
+                    removeElement(root, "Letterer");
+                    removeElement(root, "CoverArtist");
+                });
+                helper.copyCategories(restoreMode, clearFlags != null && clearFlags.isCategories(), set -> {
+                    setElement(doc, root, "Genre", join(set));
+                    removeElement(root, "Tags");
+                });
+
+                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                transformer.transform(new DOMSource(doc), new StreamResult(baos));
+                byte[] xmlBytes = baos.toByteArray();
+
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    if (existing != null && entry.getName().equals(existing.getName())) {
+                        continue;
+                    }
+                    zos.putNextEntry(new ZipEntry(entry.getName()));
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        is.transferTo(zos);
+                    }
+                    zos.closeEntry();
+                }
+
+                String entryName = existing != null ? existing.getName() : "ComicInfo.xml";
+                zos.putNextEntry(new ZipEntry(entryName));
+                zos.write(xmlBytes);
+                zos.closeEntry();
+            }
+            Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            log.warn("Failed to write metadata to CBZ file {}: {}", file.getName(), e.getMessage(), e);
+        }
+    }
+
+    private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            if ("comicinfo.xml".equalsIgnoreCase(entry.getName())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Document buildSecureDocument(InputStream is) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setExpandEntityReferences(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(is);
+    }
+
+    private void setElement(Document doc, Element root, String tag, String value) {
+        removeElement(root, tag);
+        if (value != null && !value.isBlank()) {
+            Element el = doc.createElement(tag);
+            el.setTextContent(value);
+            root.appendChild(el);
+        }
+    }
+
+    private void removeElement(Element root, String tag) {
+        NodeList nodes = root.getElementsByTagName(tag);
+        for (int i = nodes.getLength() - 1; i >= 0; i--) {
+            root.removeChild(nodes.item(i));
+        }
+    }
+
+    private void setDateElements(Document doc, Element root, LocalDate date) {
+        if (date == null) {
+            removeElement(root, "Year");
+            removeElement(root, "Month");
+            removeElement(root, "Day");
+            return;
+        }
+        setElement(doc, root, "Year", Integer.toString(date.getYear()));
+        setElement(doc, root, "Month", Integer.toString(date.getMonthValue()));
+        setElement(doc, root, "Day", Integer.toString(date.getDayOfMonth()));
+    }
+
+    private String join(Set<String> set) {
+        return (set == null || set.isEmpty()) ? null : String.join(", ", set);
+    }
+
+    private String formatFloat(Float val) {
+        if (val == null) return null;
+        if (val % 1 == 0) return Integer.toString(val.intValue());
+        return String.format(java.util.Locale.US, "%s", val);
+    }
+
+    @Override
+    public BookFileType getSupportedBookType() {
+        return BookFileType.CBX;
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -20,15 +20,19 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDate;
 import java.util.Enumeration;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import com.github.junrar.Archive;
+import com.github.junrar.rarfile.FileHeader;
 
 @Slf4j
 @Component
@@ -37,85 +41,207 @@ public class CbxMetadataWriter implements MetadataWriter {
     @Override
     public void writeMetadataToFile(File file, BookMetadataEntity metadata, String thumbnailUrl, boolean restoreMode, MetadataClearFlags clearFlags) {
         try {
-            Path temp = Files.createTempFile("cbx_edit", ".cbz");
-            try (ZipFile zipFile = new ZipFile(file);
-                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(temp))) {
+            String nameLower = file.getName().toLowerCase();
+            boolean isCbz = nameLower.endsWith(".cbz");
+            boolean isCbr = nameLower.endsWith(".cbr");
 
-                ZipEntry existing = findComicInfoEntry(zipFile);
-                Document doc;
-                if (existing != null) {
-                    try (InputStream is = zipFile.getInputStream(existing)) {
-                        doc = buildSecureDocument(is);
+            if (!isCbz && !isCbr) {
+                log.warn("Unsupported file type for CBX writer: {}", file.getName());
+                return;
+            }
+
+            // Build (or load and update) ComicInfo.xml as a Document
+            Document doc;
+            if (isCbz) {
+                try (ZipFile zipFile = new ZipFile(file)) {
+                    ZipEntry existing = findComicInfoEntry(zipFile);
+                    if (existing != null) {
+                        try (InputStream is = zipFile.getInputStream(existing)) {
+                            doc = buildSecureDocument(is);
+                        }
+                    } else {
+                        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                        DocumentBuilder builder = factory.newDocumentBuilder();
+                        doc = builder.newDocument();
+                        doc.appendChild(doc.createElement("ComicInfo"));
                     }
-                } else {
-                    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-                    DocumentBuilder builder = factory.newDocumentBuilder();
-                    doc = builder.newDocument();
-                    doc.appendChild(doc.createElement("ComicInfo"));
                 }
-                Element root = doc.getDocumentElement();
-                MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
-
-                helper.copyTitle(restoreMode, clearFlags != null && clearFlags.isTitle(), val -> setElement(doc, root, "Title", val));
-                helper.copyDescription(restoreMode, clearFlags != null && clearFlags.isDescription(), val -> {
-                    setElement(doc, root, "Summary", val);
-                    removeElement(root, "Description");
-                });
-                helper.copyPublisher(restoreMode, clearFlags != null && clearFlags.isPublisher(), val -> setElement(doc, root, "Publisher", val));
-                helper.copySeriesName(restoreMode, clearFlags != null && clearFlags.isSeriesName(), val -> setElement(doc, root, "Series", val));
-                helper.copySeriesNumber(restoreMode, clearFlags != null && clearFlags.isSeriesNumber(), val -> setElement(doc, root, "Number", formatFloat(val)));
-                helper.copySeriesTotal(restoreMode, clearFlags != null && clearFlags.isSeriesTotal(), val -> setElement(doc, root, "Count", val != null ? val.toString() : null));
-                helper.copyPublishedDate(restoreMode, clearFlags != null && clearFlags.isPublishedDate(), date -> setDateElements(doc, root, date));
-                helper.copyPageCount(restoreMode, clearFlags != null && clearFlags.isPageCount(), val -> setElement(doc, root, "PageCount", val != null ? val.toString() : null));
-                helper.copyLanguage(restoreMode, clearFlags != null && clearFlags.isLanguage(), val -> setElement(doc, root, "LanguageISO", val));
-                helper.copyAuthors(restoreMode, clearFlags != null && clearFlags.isAuthors(), set -> {
-                    setElement(doc, root, "Writer", join(set));
-                    removeElement(root, "Penciller");
-                    removeElement(root, "Inker");
-                    removeElement(root, "Colorist");
-                    removeElement(root, "Letterer");
-                    removeElement(root, "CoverArtist");
-                });
-                helper.copyCategories(restoreMode, clearFlags != null && clearFlags.isCategories(), set -> {
-                    setElement(doc, root, "Genre", join(set));
-                    removeElement(root, "Tags");
-                });
-
-                Transformer transformer = TransformerFactory transformerFactory = TransformerFactory.newInstance();
-                transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-                Transformer transformer = transformerFactory.newTransformer();
-                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                transformer.transform(new DOMSource(doc), new StreamResult(baos));
-                byte[] xmlBytes = baos.toByteArray();
-
-                Enumeration<? extends ZipEntry> entries = zipFile.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    if (existing != null && entry.getName().equals(existing.getName())) {
-                        continue;
+            } else {
+                // .cbr: try to read existing ComicInfo.xml if present; otherwise create new doc
+                try (Archive archive = new Archive(file)) {
+                    FileHeader existing = findComicInfoHeader(archive);
+                    if (existing != null) {
+                        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                            archive.extractFile(existing, baos);
+                            try (InputStream is = new java.io.ByteArrayInputStream(baos.toByteArray())) {
+                                doc = buildSecureDocument(is);
+                            }
+                        }
+                    } else {
+                        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                        DocumentBuilder builder = factory.newDocumentBuilder();
+                        doc = builder.newDocument();
+                        doc.appendChild(doc.createElement("ComicInfo"));
                     }
-                    zos.putNextEntry(new ZipEntry(entry.getName()));
-                    try (InputStream is = zipFile.getInputStream(entry)) {
-                        is.transferTo(zos);
+                }
+            }
+
+            // Apply metadata to the Document
+            Element root = doc.getDocumentElement();
+            MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
+            helper.copyTitle(restoreMode, clearFlags != null && clearFlags.isTitle(), val -> setElement(doc, root, "Title", val));
+            helper.copyDescription(restoreMode, clearFlags != null && clearFlags.isDescription(), val -> {
+                setElement(doc, root, "Summary", val);
+                removeElement(root, "Description");
+            });
+            helper.copyPublisher(restoreMode, clearFlags != null && clearFlags.isPublisher(), val -> setElement(doc, root, "Publisher", val));
+            helper.copySeriesName(restoreMode, clearFlags != null && clearFlags.isSeriesName(), val -> setElement(doc, root, "Series", val));
+            helper.copySeriesNumber(restoreMode, clearFlags != null && clearFlags.isSeriesNumber(), val -> setElement(doc, root, "Number", formatFloat(val)));
+            helper.copySeriesTotal(restoreMode, clearFlags != null && clearFlags.isSeriesTotal(), val -> setElement(doc, root, "Count", val != null ? val.toString() : null));
+            helper.copyPublishedDate(restoreMode, clearFlags != null && clearFlags.isPublishedDate(), date -> setDateElements(doc, root, date));
+            helper.copyPageCount(restoreMode, clearFlags != null && clearFlags.isPageCount(), val -> setElement(doc, root, "PageCount", val != null ? val.toString() : null));
+            helper.copyLanguage(restoreMode, clearFlags != null && clearFlags.isLanguage(), val -> setElement(doc, root, "LanguageISO", val));
+            helper.copyAuthors(restoreMode, clearFlags != null && clearFlags.isAuthors(), set -> {
+                setElement(doc, root, "Writer", join(set));
+                removeElement(root, "Penciller");
+                removeElement(root, "Inker");
+                removeElement(root, "Colorist");
+                removeElement(root, "Letterer");
+                removeElement(root, "CoverArtist");
+            });
+            helper.copyCategories(restoreMode, clearFlags != null && clearFlags.isCategories(), set -> {
+                setElement(doc, root, "Genre", join(set));
+                removeElement(root, "Tags");
+            });
+
+            // Serialize ComicInfo.xml
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            ByteArrayOutputStream xmlBaos = new ByteArrayOutputStream();
+            transformer.transform(new DOMSource(doc), new StreamResult(xmlBaos));
+            byte[] xmlBytes = xmlBaos.toByteArray();
+
+            if (isCbz) {
+                // Repack ZIP with updated/added ComicInfo.xml
+                Path temp = Files.createTempFile("cbx_edit", ".cbz");
+                try (ZipFile zipFile = new ZipFile(file);
+                     ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(temp))) {
+                    ZipEntry existing = findComicInfoEntry(zipFile);
+                    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                    while (entries.hasMoreElements()) {
+                        ZipEntry entry = entries.nextElement();
+                        if (existing != null && entry.getName().equals(existing.getName())) {
+                            continue; // skip old ComicInfo.xml
+                        }
+                        zos.putNextEntry(new ZipEntry(entry.getName()));
+                        try (InputStream is = zipFile.getInputStream(entry)) {
+                            is.transferTo(zos);
+                        }
+                        zos.closeEntry();
                     }
+                    String entryName = existing != null ? existing.getName() : "ComicInfo.xml";
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    zos.write(xmlBytes);
                     zos.closeEntry();
                 }
+                Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                return;
+            }
 
-                String entryName = existing != null ? existing.getName() : "ComicInfo.xml";
-                zos.putNextEntry(new ZipEntry(entryName));
+            // === CBR path ===
+            // NOTE: Java libraries (junrar) don't support writing RAR. We'll shell out to a `rar` binary if available.
+            String rarBin = System.getenv().getOrDefault("BOOKLORE_RAR_BIN", "rar");
+            boolean rarAvailable;
+            try {
+                Process check = new ProcessBuilder(rarBin).redirectErrorStream(true).start();
+                check.destroy();
+                rarAvailable = true;
+            } catch (Exception ex) {
+                rarAvailable = false;
+            }
+
+            if (rarAvailable) {
+                Path tempDir = Files.createTempDirectory("cbx_rar_");
+                try {
+                    // Extract entire RAR into a temp directory
+                    try (Archive archive = new Archive(file)) {
+                        for (FileHeader fh : archive.getFileHeaders()) {
+                            String name = fh.getFileName();
+                            if (name == null || name.isBlank()) continue;
+                            Path out = tempDir.resolve(name);
+                            if (fh.isDirectory()) {
+                                Files.createDirectories(out);
+                            } else {
+                                Files.createDirectories(out.getParent());
+                                try (OutputStream os = Files.newOutputStream(out, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                                    archive.extractFile(fh, os);
+                                }
+                            }
+                        }
+                    }
+
+                    // Write/replace ComicInfo.xml in extracted tree root
+                    Path comicInfo = tempDir.resolve("ComicInfo.xml");
+                    Files.write(comicInfo, xmlBytes);
+
+                    // Rebuild RAR archive in-place (replace original file)
+                    ProcessBuilder pb = new ProcessBuilder(
+                        rarBin, "a", "-idq", "-ep1", "-ma5", file.getAbsolutePath(), "."
+                    );
+                    pb.directory(tempDir.toFile());
+                    Process p = pb.start();
+                    int code = p.waitFor();
+                    if (code == 0) {
+                        // success; original CBR replaced/updated
+                        return;
+                    } else {
+                        log.warn("RAR creation failed with exit code {}. Falling back to CBZ conversion for {}", code, file.getName());
+                    }
+                } finally {
+                    try { // cleanup temp dir
+                        java.nio.file.Files.walk(tempDir)
+                            .sorted(java.util.Comparator.reverseOrder())
+                            .forEach(path -> { try { Files.deleteIfExists(path); } catch (Exception ignore) {} });
+                    } catch (Exception ignore) {}
+                }
+            } else {
+                log.warn("`rar` binary not found. Falling back to CBZ conversion for {}", file.getName());
+            }
+
+            // Fallback: convert the CBR to CBZ containing updated ComicInfo.xml
+            Path tempZip = Files.createTempFile("cbx_edit", ".cbz");
+            try (Archive archive = new Archive(file);
+                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(tempZip))) {
+                // Copy all entries from RAR to ZIP
+                for (FileHeader fh : archive.getFileHeaders()) {
+                    if (fh.isDirectory()) continue;
+                    String entryName = fh.getFileName();
+                    if ("ComicInfo.xml".equalsIgnoreCase(entryName)) {
+                        // skip old; we'll add the updated one below
+                        continue;
+                    }
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    archive.extractFile(fh, zos);
+                    zos.closeEntry();
+                }
+                // Add updated ComicInfo.xml
+                zos.putNextEntry(new ZipEntry("ComicInfo.xml"));
                 zos.write(xmlBytes);
                 zos.closeEntry();
             }
-            Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Path target = file.toPath().resolveSibling(file.getName().substring(0, file.getName().lastIndexOf('.')) + ".cbz");
+            Files.move(tempZip, target, StandardCopyOption.REPLACE_EXISTING);
+            // Optionally remove original CBR (previous behavior requested this)
+            try { Files.deleteIfExists(file.toPath()); } catch (Exception ignore) {}
         } catch (Exception e) {
-            log.warn("Failed to write metadata to CBZ file {}: {}", file.getName(), e.getMessage(), e);
+            log.warn("Failed to write metadata for {}: {}", file.getName(), e.getMessage(), e);
         }
     }
 
@@ -125,6 +251,16 @@ public class CbxMetadataWriter implements MetadataWriter {
             ZipEntry entry = entries.nextElement();
             if ("comicinfo.xml".equalsIgnoreCase(entry.getName())) {
                 return entry;
+            }
+        }
+        return null;
+    }
+
+    private FileHeader findComicInfoHeader(Archive archive) {
+        for (FileHeader fh : archive.getFileHeaders()) {
+            String name = fh.getFileName();
+            if (name != null && name.equalsIgnoreCase("ComicInfo.xml")) {
+                return fh;
             }
         }
         return null;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -238,8 +238,12 @@ public class CbxMetadataWriter implements MetadataWriter {
             }
             Path target = file.toPath().resolveSibling(file.getName().substring(0, file.getName().lastIndexOf('.')) + ".cbz");
             Files.move(tempZip, target, StandardCopyOption.REPLACE_EXISTING);
-            // Optionally remove original CBR (previous behavior requested this)
-            try { Files.deleteIfExists(file.toPath()); } catch (Exception ignore) {}
+            
+            try { 
+                // Remove original CBR after conversion
+                log.info("Removing original CBR file: {}", file.getAbsolutePath());
+                Files.deleteIfExists(file.toPath());
+            } catch (Exception ignored) { /* if field/name differs, adjust in entity */ }
         } catch (Exception e) {
             log.warn("Failed to write metadata for {}: {}", file.getName(), e.getMessage(), e);
         }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -40,6 +40,15 @@ public class CbxMetadataWriter implements MetadataWriter {
 
     @Override
     public void writeMetadataToFile(File file, BookMetadataEntity metadata, String thumbnailUrl, boolean restoreMode, MetadataClearFlags clearFlags) {
+        Path backup = null;
+        boolean writeSucceeded = false;
+        try {
+            // Create a backup next to the source file (temp name, safe to delete later)
+            backup = Files.createTempFile(file.getParentFile().toPath(), "cbx_backup_", ".bak");
+            Files.copy(file.toPath(), backup, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception ex) {
+            log.warn("Unable to create backup for {}: {}", file.getAbsolutePath(), ex.getMessage(), ex);
+        }
         try {
             String nameLower = file.getName().toLowerCase();
             boolean isCbz = nameLower.endsWith(".cbz");
@@ -152,6 +161,7 @@ public class CbxMetadataWriter implements MetadataWriter {
                     zos.closeEntry();
                 }
                 Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                writeSucceeded = true;
                 return;
             }
 
@@ -199,6 +209,7 @@ public class CbxMetadataWriter implements MetadataWriter {
                     Process p = pb.start();
                     int code = p.waitFor();
                     if (code == 0) {
+                        writeSucceeded = true;
                         // success; original CBR replaced/updated
                         return;
                     } else {
@@ -244,8 +255,26 @@ public class CbxMetadataWriter implements MetadataWriter {
                 log.info("Removing original CBR file: {}", file.getAbsolutePath());
                 Files.deleteIfExists(file.toPath());
             } catch (Exception ignored) { /* if field/name differs, adjust in entity */ }
+            writeSucceeded = true;
         } catch (Exception e) {
+            // Attempt to restore the original file from backup
+            try {
+                if (backup != null) {
+                    Files.copy(backup, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    log.info("Restored original file from backup after failure: {}", file.getAbsolutePath());
+                }
+            } catch (Exception restoreEx) {
+                log.warn("Failed to restore original file from backup: {} -> {}", backup, file.getAbsolutePath(), restoreEx);
+            }
             log.warn("Failed to write metadata for {}: {}", file.getName(), e.getMessage(), e);
+        } finally {
+            if (writeSucceeded && backup != null) {
+                try {
+                    Files.deleteIfExists(backup);
+                } catch (Exception ignore) {
+                    // best-effort cleanup
+                }
+            }
         }
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -84,7 +84,11 @@ public class CbxMetadataWriter implements MetadataWriter {
                     removeElement(root, "Tags");
                 });
 
-                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                Transformer transformer = TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+                Transformer transformer = transformerFactory.newTransformer();
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");
                 transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -171,7 +175,7 @@ public class CbxMetadataWriter implements MetadataWriter {
     private String formatFloat(Float val) {
         if (val == null) return null;
         if (val % 1 == 0) return Integer.toString(val.intValue());
-        return String.format(java.util.Locale.US, "%s", val);
+        return val.toString();
     }
 
     @Override


### PR DESCRIPTION
This is a follow up from #1069, extending ComicInfo.xml metadata support for both .CBZ and .CBR files.

Reding metadata:
- Reads the metadata from `ComicInfo.xml` file when adding new CBX comic files
- Retrieves the cover image from the `ComicInfo.xml` file, if available. Otherwise defaults to the first image in the compressed archive (alphabetically ordered)

Writing metadata, marching  EPUB support:
- .CBZ files: writes metadata edits back to `ComicInfo.xml` file 
- .CBR files: attempts to write metadata edits back to `ComicInfo.xml` file for .CBR files if _rar_ binary available. 
   - If .CBR edits are not possible, converts the .CBR to a .CBZ file and applies the metadata edits. 
   - Added the required edits in `BookMetadataUpdater.java` to handle the above file change before hashing `bookEntity`
- Included creating a backup of the original file before edits, which is restored if something goes wrong during the metadata update process

Closing the following open issues:
- #861 

Additional details:
- `ComicInfo.xml` schema: [https://github.com/anansi-project/comicinfo/tree/main/schema](https://github.com/anansi-project/comicinfo/tree/main/schema)