### PR TITLE
Fix: encode URI params for series names with special characters

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
@@ -472,7 +472,8 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
   openSeriesInfo(): void {
     const seriesName = this.book?.metadata?.seriesName;
     if (this.isSeriesCollapsed && seriesName) {
-      this.router.navigate(['/series', seriesName]);
+      const encodedSeriesName = encodeURIComponent(seriesName);
+      this.router.navigate(['/series', encodedSeriesName]);
     } else {
       this.openBookInfo(this.book);
     }

--- a/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/metadata/book-metadata-center-component/metadata-viewer/metadata-viewer.component.ts
@@ -543,7 +543,8 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
   }
 
   goToSeries(seriesName: string): void {
-    this.router.navigate(['/series', seriesName]);
+    const encodedSeriesName = encodeURIComponent(seriesName);
+    this.router.navigate(['/series', encodedSeriesName]);
   }
 
   goToPublisher(publisher: string): void {


### PR DESCRIPTION
Encode the series name in the URL to handle special characters (e.g., %). Without encoding, decodeURIComponent in the route crashes when such characters are present.

Linked issue: #1175

Video after fixes: 

https://github.com/user-attachments/assets/a4c77878-0a48-48b0-a946-887b6148e9a5

