### PR TITLE
fix: stop sending shelves not associated with the user

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/mapper/ShelfMapper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/mapper/ShelfMapper.java
@@ -3,9 +3,11 @@ package com.adityachandel.booklore.mapper;
 import com.adityachandel.booklore.model.dto.Shelf;
 import com.adityachandel.booklore.model.entity.ShelfEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ShelfMapper {
 
+    @Mapping(source = "user.id", target = "userId")
     Shelf toShelf(ShelfEntity shelfEntity);
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/mapper/v2/BookMapperV2.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/mapper/v2/BookMapperV2.java
@@ -1,5 +1,6 @@
 package com.adityachandel.booklore.mapper.v2;
 
+import com.adityachandel.booklore.mapper.ShelfMapper;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.LibraryPath;
@@ -11,7 +12,7 @@ import org.mapstruct.Named;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = ShelfMapper.class)
 public interface BookMapperV2 {
 
     @Mapping(source = "library.id", target = "libraryId")

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
@@ -142,12 +142,7 @@ public class BookService {
         UserBookProgressEntity userProgress = userBookProgressRepository.findByUserIdAndBookId(user.getId(), bookId).orElse(new UserBookProgressEntity());
 
         Book book = bookMapper.toBook(bookEntity);
-        if (book.getShelves() != null) {
-            book.setShelves(book.getShelves().stream()
-                    .filter(shelf -> user.getId().equals(shelf.getUserId()))
-                    .collect(Collectors.toSet()));
-        }
-
+        book.setShelves(filterShelvesByUserId(book.getShelves(), user.getId()));
         book.setLastReadTime(userProgress.getLastReadTime());
 
         if (bookEntity.getBookType() == BookFileType.PDF) {
@@ -488,6 +483,7 @@ public class BookService {
 
         return bookEntities.stream().map(bookEntity -> {
             Book book = bookMapper.toBook(bookEntity);
+            book.setShelves(filterShelvesByUserId(book.getShelves(), user.getId()));
             book.setFilePath(FileUtils.getBookFullPath(bookEntity));
             enrichBookWithProgress(book, progressMap.get(bookEntity.getId()));
             return book;
@@ -641,6 +637,13 @@ public class BookService {
                 break;
             }
         }
+    }
+
+    private Set<Shelf> filterShelvesByUserId(Set<Shelf> shelves, Long userId) {
+        if (shelves == null) return Collections.emptySet();
+        return shelves.stream()
+                .filter(shelf -> userId.equals(shelf.getUserId()))
+                .collect(Collectors.toSet());
     }
 
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
@@ -142,6 +142,12 @@ public class BookService {
         UserBookProgressEntity userProgress = userBookProgressRepository.findByUserIdAndBookId(user.getId(), bookId).orElse(new UserBookProgressEntity());
 
         Book book = bookMapper.toBook(bookEntity);
+        if (book.getShelves() != null) {
+            book.setShelves(book.getShelves().stream()
+                    .filter(shelf -> user.getId().equals(shelf.getUserId()))
+                    .collect(Collectors.toSet()));
+        }
+
         book.setLastReadTime(userProgress.getLastReadTime());
 
         if (bookEntity.getBookType() == BookFileType.PDF) {


### PR DESCRIPTION
Fix for #978 

It might make sense to filter the shelves in the book mapper itself so it happens on every use of `toBook`. But given that it's used in a lot of places and I'm not familiar with most of the project's code I'm afraid that could introduce some issue I'm unaware of. So I filtered the resulting shelves specifically in the method needed to fix the existing issue.

I tested it locally with the same setup of users and books with which I could reproduce the error and this fixes it.