### PR TITLE
Feat: set reading status using Koreader Sync Plugin

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
@@ -157,10 +157,16 @@ public class BookService {
                     .percentage(userProgress.getEpubProgressPercent())
                     .build());
             if (userProgress.getKoreaderProgressPercent() != null) {
-                if (book.getKoreaderProgress() == null) {
-                    book.setKoreaderProgress(KoProgress.builder().build());
+                var userReadProgress = userProgress.getKoreaderProgressPercent() * 100;
+                book.getKoreaderProgress().setPercentage(userReadProgress);
+                if (userReadProgress >= 99.5f) {
+                    book.setReadStatus(String.valueOf(ReadStatus.READ));
+                } else if (userReadProgress > 0.01f) {
+                    book.setReadStatus(String.valueOf(ReadStatus.READING));
+                } else {
+                    book.setReadStatus(String.valueOf(ReadStatus.UNREAD));
                 }
-                book.getKoreaderProgress().setPercentage(userProgress.getKoreaderProgressPercent() * 100);
+
             }
         }
         if (bookEntity.getBookType() == BookFileType.CBX) {


### PR DESCRIPTION
This small PR is my attempt at setting the read status for a book based on the KoReader Sync plugin. While I am fairly new to Java dev, and therefore currently not set up to test this locally, I assume this should work, but changes are welcome. 

This was created in reference to [this discord feature request](https://discord.com/channels/1379932933581963444/1379934554957152336/1424024474898141255)

I'm not sure if this can be applied to the other types as well, I only have epubs in my library and therefore only added the part to  the epub area

Feedback / Suggestions are welcome 